### PR TITLE
Add travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: python
+
+# Setting sudo to false opts in to Travis-CI container-based builds.
+sudo: false
+
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+
+env:
+  global:
+    - TEST_DIR=/tmp/pyftp
+    - CONDA_DEPS="numpy scipy pytest pip"
+    - PIP_DEPS="astroML gatspy"
+    - CONDA_FORGE_DEPS="pynfft"
+
+before_install:
+    - export MINICONDA=$HOME/miniconda
+    - export PATH="$MINICONDA/bin:$PATH"
+    - hash -r
+    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+    - bash miniconda.sh -b -f -p $MINICONDA
+    - conda config --set always_yes yes
+    - conda update -q conda
+    - conda info -a
+
+install:
+  - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION $CONDA_DEPS
+  - source activate test-env
+  - conda install -c conda-forge $CONDA_FORGE_DEPS
+  - pip install $PIP_DEPS
+  - python setup.py install
+
+script:
+  - mkdir -p $TEST_DIR
+  - cd $TEST_DIR && py.test --pyargs pyftp


### PR DESCRIPTION
This adds the travis script for continuous integration.

Travis will have to be activated in order for this to work, which can only be done by an admin for this repo. It's quite easy; instructions are here: https://travis-ci.org/getting_started click "sign in with github" and follow step 1 to activate this repository.

After that, we can merge this PR to trigger the tests. Once that's been done, then the unit tests will be run on Python 2.7, 3.5, and 3.6 for every commit or pull request.