### PR TITLE
Add conda install instructions

### DIFF
--- a/CONDA_INSTALL.md
+++ b/CONDA_INSTALL.md
@@ -1,0 +1,18 @@
+Installation with Conda
+=======================
+
+You can use [conda](http://conda.pydata.org) to install all the required dependencies:
+
+```
+$ conda create -n fast-template-periodogram python=3.5
+$ source activate fast-template-periodogram
+$ conda install jupyter notebook astropy pytest
+$ conda install pynfft -c conda-forge
+$ pip install gatspy
+```
+
+Next, make sure that things are working by running the unit tests:
+
+```
+$ make test
+```


### PR DESCRIPTION
I added a document with installation instructions based on conda. This could probably replace some of the details in the README, because it's much cleaner and easier.

Also, while I'm thinking of it: we may want to remove dependence on gatspy if possible. I haven't really been maintaining that, and I think the pieces we use are small enough that we don't need that dependency.