### PR TITLE
WIP: add initial SlowTemplatePeriodogram class

### DIFF
--- a/pyftp/slow_modeler.py
+++ b/pyftp/slow_modeler.py
@@ -1,0 +1,70 @@
+import numpy as np
+from scipy import optimize
+from pyftp.template import Template
+
+
+class SlowTemplatePeriodogram(object):
+    """Slow periodogram built from a template model.
+
+    When computing the periodogram, this performs a nonlinear optimization at
+    each frequency.
+
+    Parameters
+    ----------
+    t : array_like
+        sequence of observation times
+    y : array_like
+        sequence of observations associated with times t
+    dy : float, array_like (optional)
+        error or sequence of observational errors associated with times t
+    template : Template object
+        callable object that returns the template value as a function of phase
+    """
+    def __init__(self, t, y, dy, template):
+        # Validate arrays
+        t, y, dy = np.broadcast_arrays(t, y, dy)
+        assert t.ndim == 1
+        self.t = t
+        self.y = y
+        self.dy = dy
+        self.template = template
+
+    def _minimize_chi2_at_single_freq(self, freq):
+        t_phase = (self.t * freq) % 1
+        def chi2(params):
+            phase, offset, amp = params
+            y_model = offset + amp * self.template(self.t * freq - phase)
+            return np.sum((y_model - self.y) ** 2 / self.dy ** 2)
+        params0 = [0, np.mean(self.y), np.std(self.y)]
+        res = optimize.minimize(chi2, params0, method='l-bfgs-b')
+        return res
+
+    def _chi2_ref(self):
+        weights = 1. / self.dy ** 2
+        weights /= weights.sum()
+        ymean = np.dot(weights, self.y)
+        return np.sum((self.y - ymean) ** 2 / self.dy ** 2)
+
+    def power(self, freq):
+        """Compute a template-based periodogram
+
+        Parameters
+        ----------
+        freq : array_like
+            frequencies at which to evaluate the template periodogram
+
+        Returns
+        -------
+        power : np.ndarray
+            normalized power spectrum computed at the given frequencies
+        """
+        freq = np.asarray(freq)
+        shape = freq.shape
+        freq = freq.ravel()
+        results = list(map(self._minimize_chi2_at_single_freq, freq))
+        num_misses = sum([not res.success for res in results])
+        if num_misses:
+            warnings.warn("{0}/{1} frequency values failed to "
+                          "converge".format(num_misses, len(freq)))
+        chi2 = np.array([res.fun for res in results])
+        return (1 - chi2 / self._chi2_ref()).reshape(shape)

--- a/pyftp/slow_template_periodogram.py
+++ b/pyftp/slow_template_periodogram.py
@@ -72,6 +72,6 @@ class SlowTemplatePeriodogram(object):
         failures = sum([not res.success for res in results])
         if failures:
             raise RuntimeError("{0}/{1} frequency values failed to converge"
-                               "".format(failures, freq.size)))
+                               "".format(failures, freq.size))
         chi2 = np.array([res.fun for res in results])
         return np.reshape(1 - chi2 / self._chi2_ref(), freq.shape)

--- a/pyftp/slow_template_periodogram.py
+++ b/pyftp/slow_template_periodogram.py
@@ -7,7 +7,8 @@ class SlowTemplatePeriodogram(object):
     """Slow periodogram built from a template model.
 
     When computing the periodogram, this performs a nonlinear optimization at
-    each frequency.
+    each frequency. This is used mainly for testing the faster method
+    available in FastTemplatePeriodogram
 
     Parameters
     ----------
@@ -20,14 +21,26 @@ class SlowTemplatePeriodogram(object):
     template : Template object
         callable object that returns the template value as a function of phase
     """
-    def __init__(self, t, y, dy, template):
-        # Validate arrays
-        t, y, dy = np.broadcast_arrays(t, y, dy)
-        assert t.ndim == 1
-        self.t = t
-        self.y = y
-        self.dy = dy
+    def __init__(self, t, y, dy=None, template=None):
+        self.t, self.y, self.dy = self._validate_inputs(t, y, dy)
         self.template = template
+
+    def _validate_inputs(self, t, y, dy):
+        if dy is None:
+            # TODO: handle dy = None case more efficiently
+            t, y, dy = np.broadcast_arrays(t, y, 1.0)
+        else:
+            t, y, dy = np.broadcast_arrays(t, y, dy)
+        if t.ndim != 1:
+            raise ValueError("Inputs (t, y, dy) must be 1-dimensional")
+        return t, y, dy
+
+    def _chi2_ref(self):
+        """Compute the reference chi-square"""
+        weights = self.dy ** -2
+        weights /= weights.sum()
+        ymean = np.dot(weights, self.y)
+        return np.sum((self.y - ymean) ** 2 / self.dy ** 2)
 
     def _minimize_chi2_at_single_freq(self, freq):
         t_phase = (self.t * freq) % 1
@@ -36,17 +49,10 @@ class SlowTemplatePeriodogram(object):
             y_model = offset + amp * self.template(self.t * freq - phase)
             return np.sum((y_model - self.y) ** 2 / self.dy ** 2)
         params0 = [0, np.mean(self.y), np.std(self.y)]
-        res = optimize.minimize(chi2, params0, method='l-bfgs-b')
-        return res
-
-    def _chi2_ref(self):
-        weights = 1. / self.dy ** 2
-        weights /= weights.sum()
-        ymean = np.dot(weights, self.y)
-        return np.sum((self.y - ymean) ** 2 / self.dy ** 2)
+        return optimize.minimize(chi2, params0, method='l-bfgs-b')
 
     def power(self, freq):
-        """Compute a template-based periodogram
+        """Compute a template-based periodogram at the given frequencies
 
         Parameters
         ----------
@@ -59,12 +65,10 @@ class SlowTemplatePeriodogram(object):
             normalized power spectrum computed at the given frequencies
         """
         freq = np.asarray(freq)
-        shape = freq.shape
-        freq = freq.ravel()
-        results = list(map(self._minimize_chi2_at_single_freq, freq))
-        num_misses = sum([not res.success for res in results])
-        if num_misses:
+        results = list(map(self._minimize_chi2_at_single_freq, freq.flat))
+        failures = sum([not res.success for res in results])
+        if failures:
             warnings.warn("{0}/{1} frequency values failed to "
-                          "converge".format(num_misses, len(freq)))
+                          "converge".format(failures, len(freq)))
         chi2 = np.array([res.fun for res in results])
-        return (1 - chi2 / self._chi2_ref()).reshape(shape)
+        return np.reshape(1 - chi2 / self._chi2_ref(), freq.shape)

--- a/pyftp/tests/test_modeler.py
+++ b/pyftp/tests/test_modeler.py
@@ -2,8 +2,6 @@
 import numpy as np
 from ..modeler import FastTemplateModeler
 from ..template import Template
-from numpy.testing import assert_allclose
-from scipy.interpolate import interp1d
 
 import pytest
 
@@ -14,6 +12,7 @@ def template_function(phase,
     n = 1 + np.arange(len(c_n))[:, np.newaxis]
     return (np.dot(c_n, np.cos(2 * np.pi * n * phase)) +
             np.dot(s_n, np.sin(2 * np.pi * n * phase)))
+
 
 @pytest.fixture
 def template():
@@ -30,6 +29,7 @@ def data(N=30, T=5, period=0.9, coeffs=(5, 10),
     y += yerr * rand.randn(N)
     return t, y, yerr * np.ones_like(y)
 
+
 def weights(yerr):
     assert(all(yerr > 0))
 
@@ -39,6 +39,7 @@ def weights(yerr):
 
 def shift_template(template, tau):
     return lambda phase, tau=tau : template(phase - tau)
+
 
 def get_amplitude_and_offset(freq, template, data):
     """ 
@@ -76,6 +77,7 @@ def chi2_template_fit(freq, template, data):
 
     return np.dot(w, (y - amp * M - offset)**2)
 
+
 def direct_periodogram(freq, template, data, nshifts=100):
     """
     computes periodogram at a given frequency directly, 
@@ -93,6 +95,7 @@ def direct_periodogram(freq, template, data, nshifts=100):
     chi2s = [ chi2_tau(tau) for tau in taus ]
 
     return 1. - min(chi2s) / chi2_0
+
 
 def truncate_template(phase, y, nharmonics):
     fft = np.fft.fft(y[::-1])

--- a/pyftp/tests/test_slow_template_periodogram.py
+++ b/pyftp/tests/test_slow_template_periodogram.py
@@ -36,11 +36,11 @@ def test_vs_lombscargle():
     assert_allclose(power1, power2)
 
 
-@pytest.mark.parametrize('n', [1, 2, 3, 4])
-def test_zero_noise(n):
+@pytest.mark.parametrize('nharmonics', [1, 2, 3, 4])
+def test_zero_noise(nharmonics):
     # in the zero-noise perfect template case, the true frequency should
     # have power = 1
-    template = generate_template(1)
+    template = generate_template(nharmonics)
     t, y, _ = generate_data(template, N=100, tmin=0, tmax=100, freq=0.1, dy=0)
     dy = None
     power = SlowTemplatePeriodogram(t, y, dy, template=template).power(0.1)

--- a/pyftp/tests/test_slow_template_periodogram.py
+++ b/pyftp/tests/test_slow_template_periodogram.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+from gatspy.periodic import LombScargle
+
+from numpy.testing import assert_allclose
+import pytest
+
+from ..slow_template_periodogram import SlowTemplatePeriodogram
+from ..template import Template
+
+
+def generate_template(nharmonics, rseed=0):
+    rng = np.random.RandomState(rseed)
+    c_n, s_n = rng.randn(2, nharmonics) * 1. / np.arange(1, nharmonics + 1)
+    return Template(c_n, s_n)
+
+
+def generate_data(template, N, tmin, tmax, freq, dy=0.1,
+                  phase=0, amp=1, offset=10, rseed=0):
+    rng = np.random.RandomState(rseed)
+    t = tmin + (tmax - tmin) * np.random.rand(N)
+    y = offset + amp * template(t * freq - phase) + dy * rng.randn(N)
+    return t, y, dy
+
+
+def test_vs_lombscargle():
+    # one-component template should be identical to a
+    # Lomb-Scargle periodogram with floating-mean
+    template = generate_template(1)
+    t, y, dy = generate_data(template, N=100, tmin=0, tmax=100, freq=0.1)
+
+    freq = np.linspace(0.01, 1, 10)
+    power1 = SlowTemplatePeriodogram(t, y, dy, template=template).power(freq)
+    power2 = LombScargle(fit_offset=True).fit(t, y, dy).periodogram(1. / freq)
+
+    assert_allclose(power1, power2)
+
+
+@pytest.mark.parametrize('n', [1, 2, 3, 4])
+def test_zero_noise(n):
+    # in the zero-noise perfect template case, the true frequency should
+    # have power = 1
+    template = generate_template(1)
+    t, y, _ = generate_data(template, N=100, tmin=0, tmax=100, freq=0.1, dy=0)
+    dy = None
+    power = SlowTemplatePeriodogram(t, y, dy, template=template).power(0.1)
+    assert_allclose(power, 1)


### PR DESCRIPTION
I noticed that in the new model tests, there's a whole lot of functionality that essentially computes a slow periodogram by direct grid-search minimization.

I think it's cleaner to instead have an interface in the package itself that computes this. Here's my initial attempt at a ``SlowTemplatePeriodogram``, with an API similar to ``astropy.stats.LombScargle``.

This is a work in progress (WIP), so please don't merge yet, but I wanted to get your thoughts on this. Once we feel like this is in pretty good shape, we can work on a new version of the Fast periodogram that should produce the same output to within optimization errors. This leads to a really natural and concise way to test the main method.

Example usage:

```python
%matplotlib inline
import matplotlib.pyplot as plt
import numpy as np

from pyftp.template import Template
from pyftp.slow_template_periodogram import SlowTemplatePeriodogram
```

```python
def generate_template(nharmonics, rseed=0):
    rng = np.random.RandomState(rseed)
    c_n, s_n = rng.randn(2, nharmonics) * 1. / np.arange(1, nharmonics + 1)
    return Template(c_n, s_n)

def generate_data(template, N, tmin, tmax, freq, dy=0.1, phase=0, amp=1, offset=10, rseed=0):
    rng = np.random.RandomState(rseed)
    t = tmin + (tmax - tmin) * np.random.rand(N)
    y = offset + amp * template(t * freq - phase) + dy * rng.randn(N)
    return t, y, dy
```

```python
fig, ax = plt.subplots(1, 2, figsize=(12, 4))

template = generate_template(4)
t_grid = np.linspace(0, 1, 1000)
ax[0].plot(t_grid, template(t_grid))

t, y, dy = generate_data(template, 100, 0, 100, freq=0.1, dy=0.5)
ax[1].errorbar(t, y, dy, fmt='.k', ecolor='gray', capsize=0);
```
![gaeuunwdpndjswsiiiiiopbltfijiiiiiiltmskmiiiiopdhpjiiiiiiqh6tyiiiiiikeuykiyiiicjkmskmiiiiopdhpjiiiiiiqh6tyiiiiiikef8frab4carjctsaaaaasuvork5cyii](https://cloud.githubusercontent.com/assets/781659/23975491/509bc450-099e-11e7-8488-5ee74e9fb03a.png)

```python
stp = SlowTemplatePeriodogram(t, y, dy, template)
freq = np.linspace(0.01, 1.0, 500)

plt.plot(freq, stp.power(freq))
plt.ylim(0, 1);
```
![b2o52btugrxsaaaaaelftksuqmcc](https://cloud.githubusercontent.com/assets/781659/23975494/53f10ea8-099e-11e7-949b-dbea36e24742.png)
