### PR TITLE
v0.1 code-health: remove no-op positivity knob, complex128 coeffs, version fix

### DIFF
--- a/ftperiodogram/__init__.py
+++ b/ftperiodogram/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.41"
+from .version import __version__
 
 from .modeler import FastTemplatePeriodogram, FastMultiTemplatePeriodogram
 from .template import Template

--- a/ftperiodogram/core.py
+++ b/ftperiodogram/core.py
@@ -48,7 +48,7 @@ def template_fit_from_sums(cn, sn, sums, ybar, YY):
     
     # compute YM
     aYC = alpha * (sums.YC - 1j * sums.YS)
-    YM = pol.Polynomial(np.concatenate((np.conj(aYC)[::-1], [0], aYC)).astype(np.complex64))
+    YM = pol.Polynomial(np.concatenate((np.conj(aYC)[::-1], [0], aYC)).astype(np.complex128))
 
     # compute MM
     UU = sums.CC + 1j * sums.CS
@@ -59,7 +59,7 @@ def template_fit_from_sums(cn, sn, sums, ybar, YY):
     SS = np.conj(CC)
 
     # TODO : use numpy to speed this up.
-    MM = np.zeros(4 * H + 1, dtype=np.complex64)
+    MM = np.zeros(4 * H + 1, dtype=np.complex128)
 
     CC = CC[::-1, :]
     CS = CS.T
@@ -112,8 +112,7 @@ def template_fit_from_sums(cn, sn, sums, ybar, YY):
     return best_params, pdg_phi[i]
 
 def fit_template(t, y, dy, cn, sn, freq, sums=None,
-                       allow_negative_amplitudes=True, zeros=None,
-                       small=1E-7):
+                       zeros=None, small=1E-7):
     r"""
     Fits periodic template to data at a single frequency
 
@@ -129,19 +128,11 @@ def fit_template(t, y, dy, cn, sn, freq, sums=None,
         Fourier (cosine) coefficients of the template
     sn : array_like
         Fourier (sine) coefficients of the template
-    ptensors : np.ndarray, shape = (H, H, H, L)
-        Polynomial coefficients from template; H is the number of
-        harmonics, L is the (maximum) length of the polynomial
     freq : float
         Frequency at which to fit the template
     sums : Summations, optional
         Precomputed summations (C, S, CC, CS, SS, YC, YS). Default
         is None, which means the sums are computed directly (no NFFT)
-    allow_negative_amplitudes : bool, optional, (default = True)
-        Specifies whether or not negative amplitude solutions are allowed.
-        They are automatically forbidden for H=1 (since this is equivalent
-        to a phase shift). If no positive amplitude solutions are found and
-        allow_negative_amplitudes = False, the periodogram is set to 0
 
     Returns
     -------
@@ -166,8 +157,7 @@ def fit_template(t, y, dy, cn, sn, freq, sums=None,
 
 
 def template_periodogram(t, y, dy, cn, sn, freqs,
-                        summations=None, allow_negative_amplitudes=True,
-                        fast=True):
+                        summations=None, fast=True):
     r"""
     Produces a template periodogram using a single template
 
@@ -183,9 +173,6 @@ def template_periodogram(t, y, dy, cn, sn, freqs,
         Fourier (cosine) coefficients of the template
     sn : array_like
         Fourier (sine) coefficients of the template
-    ptensors : np.ndarray, shape = (H, H, H, L), optional
-        Polynomial coefficients from template; H is the number of
-        harmonics, L is the (maximum) length of the polynomial
     freqs : array_like
         Frequencies at which to fit the template
     summations : list of Summations, optional
@@ -193,11 +180,6 @@ def template_periodogram(t, y, dy, cn, sn, freqs,
         in freqs. Default is None, which means the sums are computed via
         direct summations (if `fast=False`) or via fast summations (NFFT, if
         `fast=True`)
-    allow_negative_amplitudes : bool, optional, (default = True)
-        Specifies whether or not negative amplitude solutions are allowed.
-        They are automatically forbidden for H=1 (since this is equivalent
-        to a phase shift). If no positive amplitude solutions are found and
-        allow_negative_amplitudes = False, the periodogram is set to 0
 
     Returns
     -------

--- a/ftperiodogram/modeler.py
+++ b/ftperiodogram/modeler.py
@@ -102,17 +102,9 @@ class FastTemplatePeriodogram(object):
     ----------
     template : Template
         Template to fit (must be Template instance)
-    allow_negative_amplitudes : bool (optional, default=True)
-        if False, then negative optimal template amplitudes
-        will be replaced with zero-amplitude solutions. A False
-        value prevents the modeler from fitting an inverted
-        template to the data, but does not attempt to find the
-        best positive amplitude solution, which would require
-        substantially more computational resources.
     """
-    def __init__(self, template=None, allow_negative_amplitudes=True):
+    def __init__(self, template=None):
         self.template = template
-        self.allow_negative_amplitudes = allow_negative_amplitudes
         self.t, self.y, self.dy = None, None, None
         self.best_model = None
 
@@ -182,8 +174,7 @@ class FastTemplatePeriodogram(object):
         """
         freq = float(freq)
         p, parameters = pdg.fit_template(self.t, self.y, self.dy,
-                                         self.template.c_n, self.template.s_n, freq,
-                                         allow_negative_amplitudes=self.allow_negative_amplitudes)
+                                         self.template.c_n, self.template.s_n, freq)
         return TemplateModel(self.template, parameters=parameters,
                              frequency=freq)
 
@@ -261,8 +252,7 @@ class FastTemplatePeriodogram(object):
         """
         frequency = self.autofrequency(**kwargs)
         p, bfpars = pdg.template_periodogram(self.t, self.y, self.dy, self.template.c_n,
-                            self.template.s_n, frequency, fast=fast,
-                            allow_negative_amplitudes=self.allow_negative_amplitudes)
+                            self.template.s_n, frequency, fast=fast)
 
         if save_best_model:
             i = np.argmax(p)
@@ -299,8 +289,7 @@ class FastTemplatePeriodogram(object):
 
         def fitter(freq):
             return pdg.fit_template(self.t, self.y, self.dy,
-                                    self.template.c_n, self.template.s_n,freq,
-                                    allow_negative_amplitudes=self.allow_negative_amplitudes)
+                                    self.template.c_n, self.template.s_n,freq)
 
         p, bfpars = zip(*map(fitter, frequency))
         p = np.array(p)
@@ -338,17 +327,9 @@ class FastMultiTemplatePeriodogram(FastTemplatePeriodogram):
     ----------
     templates : list of Template
         Templates to fit (must be list of Template instances)
-    allow_negative_amplitudes : bool (optional, default=True)
-        if False, then negative optimal template amplitudes
-        will be replaced with zero-amplitude solutions. A False
-        value prevents the modeler from fitting an inverted
-        template to the data, but does not attempt to find the
-        best positive amplitude solution, which would require
-        substantially more computational resources.
     """
-    def __init__(self, templates=None, allow_negative_amplitudes=True):
+    def __init__(self, templates=None):
         self.templates = templates
-        self.allow_negative_amplitudes = allow_negative_amplitudes
         self.t, self.y, self.dy = None, None, None
         self.best_model = None
 
@@ -385,8 +366,7 @@ class FastMultiTemplatePeriodogram(FastTemplatePeriodogram):
             raise ValueError('fit_model requires float argument')
 
         p, parameters = zip(*[pdg.fit_template(self.t, self.y, self.dy,
-                                               template.c_n, template.s_n, freq,
-                                               allow_negative_amplitudes=self.allow_negative_amplitudes)
+                                               template.c_n, template.s_n, freq)
                               for template in self.templates ])
 
         i = np.argmax(p)
@@ -416,8 +396,7 @@ class FastMultiTemplatePeriodogram(FastTemplatePeriodogram):
         frequency = self.autofrequency(**kwargs)
 
         results = [pdg.template_periodogram(self.t, self.y, self.dy, template.c_n,
-                                            template.s_n, frequency, fast=fast,
-                                            allow_negative_amplitudes=self.allow_negative_amplitudes)
+                                            template.s_n, frequency, fast=fast)
                    for template in self.templates]
 
         p, bfpars = zip(*results)
@@ -460,9 +439,8 @@ class FastMultiTemplatePeriodogram(FastTemplatePeriodogram):
 
         p, bfpars = pdg.template_periodogram(self.t, self.y, self.dy,
                                              template.c_n, template.s_n,
-                                             frequency, 
-                                             fast=fast, 
-                                             allow_negative_amplitudes=self.allow_negative_amplitudes)
+                                             frequency,
+                                             fast=fast)
         p = np.asarray(p)
         if save_best_model:
             i = np.argmax(p)

--- a/ftperiodogram/summations.py
+++ b/ftperiodogram/summations.py
@@ -1,4 +1,3 @@
-#from future import __division__
 from nfft import nfft_adjoint
 from .utils import Summations
 import numpy as np

--- a/ftperiodogram/tests/test_modeler.py
+++ b/ftperiodogram/tests/test_modeler.py
@@ -405,8 +405,7 @@ def test_inject_and_recover(nharmonics, ndata, rseed, period=1.2, tol=1E-2):
     t, y, yerr = data_from_template(template, parameters, period=period,
                                          yerr=0.0001, rseed=rseed)
 
-    max_p, best_pars = fit_template(t, y, yerr, template.c_n, template.s_n, 1./period,
-                                    allow_negative_amplitudes=True)
+    max_p, best_pars = fit_template(t, y, yerr, template.c_n, template.s_n, 1./period)
 
     # if nharmonics == 1 and best_pars.a < 0:
     #     best_pars = ModelFitParams(a=-best_pars.a, b=-best_pars.b, c=best_pars.c, sgn=-best_pars.sgn)


### PR DESCRIPTION
Independent cleanup pass for the v0.1 release. Touches `core.py`, `modeler.py`, `__init__.py`, `summations.py` (and one test call); does **not** modify the regression bar, so it is independent of #34 and can merge in either order.

## Changes

- **Remove the no-op `allow_negative_amplitudes` parameter.** It was accepted by `fit_template`/`template_periodogram` and threaded from the modeler classes, but never reached `template_fit_from_sums`, which selects the global-best polynomial root via `argmax` regardless of the sign of θ₁. The positivity filter was dropped in the 2017 refactor (`0dab22a`) and the parameter + docstrings were left behind, so passing `False` silently did nothing. Negative-amplitude solutions remain allowed (unchanged behavior — just no false promise). Real θ₁>0 enforcement in `power(...)` is deferred to **v0.2**, consistent with §2.1 of the paper.
- **`complex64` → `complex128`** for the `YM`/`MM` polynomial coefficients in `core.py`. The single-precision cast truncated the coefficients near the ~1e-7 precision floor; the root finder already promoted to double. Validated against the tightened `atol=1e-6` precision tests in #34.
- **`__version__`** now sourced from `version.py` (was hardcoded `0.9.41` while the package is `1.0.0`; runtime now reports `1.0.0`).
- Drop dead `ptensors` docstring args (parameter removed in `0dab22a`) and a broken commented `#from future import __division__` line.

## Tests

`pytest ftperiodogram/tests` → 91 passed, 1 skipped, 2 failed. The 2 failures (`test_zero_noise[None-2/3]` in `SlowTemplatePeriodogram`) are pre-existing on master and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)