### PR TITLE
multiband: FastMultibandTemplatePeriodogram (4 sharing modes + catalog)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,42 @@ inside the ``notebooks/`` directory::
 	$ jupyter notebook
 
 
+Multiband periodograms
+----------------------
+
+``FastMultibandTemplatePeriodogram`` fits a template to data observed in several
+photometric bands at once, using the flat ``(t, y, bands, dy)`` convention of
+``astropy``/``gatspy`` ``LombScargleMultiband`` (one row per observation, with a
+band label)::
+
+	from ftperiodogram import Template, FastMultibandTemplatePeriodogram
+
+	template = Template.from_sampled(my_phased_lightcurve, nharmonics=6)
+
+	model = FastMultibandTemplatePeriodogram(template, mode='floating_offsets')
+	model.fit(t, y, bands, dy)            # bands e.g. array of 'g'/'r'/'i'
+	frequency, power = model.autopower(minimum_frequency=1./10,
+	                                   maximum_frequency=10.)
+
+The ``mode`` selects what is shared across bands:
+
+* ``'independent'`` -- nothing shared (each band fit separately; the
+  multiphase model of VanderPlas & Ivezic 2015).
+* ``'shared_phase'`` -- the phase is shared; amplitudes and offsets float per band.
+* ``'floating_offsets'`` (default) -- amplitude and phase are shared; only the
+  per-band offset (zero point) floats. No extra inputs required.
+* ``'sesar'`` -- amplitude, phase and offset are all shared, with fixed per-band
+  relative offsets ``lambda^(k)`` supplied via ``relative_offsets`` (the
+  3-parameter model of Sesar et al. 2016). Pass
+  ``relative_offsets={band: lambda}``.
+
+For irregularly-sampled data, set ``minimum_frequency`` and ``maximum_frequency``
+explicitly rather than relying on a Nyquist heuristic. A list of templates (or
+``{band: Template}`` dicts) may be passed as a *catalog*; the periodogram then
+reports the best-fitting set at each frequency and records the winning set on
+``model.best_model.template_set_index``.
+
+
 Updates
 -------
 
@@ -139,7 +175,6 @@ For more discussion of the multiharmonic periodogram and related extensions, see
 TODO
 ----
 
-* Multi-band extensions
 * Speed improvements
 
 

--- a/README.rst.in
+++ b/README.rst.in
@@ -61,6 +61,42 @@ inside the ``notebooks/`` directory::
 	$ jupyter notebook
 
 
+Multiband periodograms
+----------------------
+
+``FastMultibandTemplatePeriodogram`` fits a template to data observed in several
+photometric bands at once, using the flat ``(t, y, bands, dy)`` convention of
+``astropy``/``gatspy`` ``LombScargleMultiband`` (one row per observation, with a
+band label)::
+
+	from ftperiodogram import Template, FastMultibandTemplatePeriodogram
+
+	template = Template.from_sampled(my_phased_lightcurve, nharmonics=6)
+
+	model = FastMultibandTemplatePeriodogram(template, mode='floating_offsets')
+	model.fit(t, y, bands, dy)            # bands e.g. array of 'g'/'r'/'i'
+	frequency, power = model.autopower(minimum_frequency=1./10,
+	                                   maximum_frequency=10.)
+
+The ``mode`` selects what is shared across bands:
+
+* ``'independent'`` -- nothing shared (each band fit separately; the
+  multiphase model of VanderPlas & Ivezic 2015).
+* ``'shared_phase'`` -- the phase is shared; amplitudes and offsets float per band.
+* ``'floating_offsets'`` (default) -- amplitude and phase are shared; only the
+  per-band offset (zero point) floats. No extra inputs required.
+* ``'sesar'`` -- amplitude, phase and offset are all shared, with fixed per-band
+  relative offsets ``lambda^(k)`` supplied via ``relative_offsets`` (the
+  3-parameter model of Sesar et al. 2016). Pass
+  ``relative_offsets={band: lambda}``.
+
+For irregularly-sampled data, set ``minimum_frequency`` and ``maximum_frequency``
+explicitly rather than relying on a Nyquist heuristic. A list of templates (or
+``{band: Template}`` dicts) may be passed as a *catalog*; the periodogram then
+reports the best-fitting set at each frequency and records the winning set on
+``model.best_model.template_set_index``.
+
+
 Updates
 -------
 
@@ -139,7 +175,6 @@ For more discussion of the multiharmonic periodogram and related extensions, see
 TODO
 ----
 
-* Multi-band extensions
 * Speed improvements
 
 

--- a/ftperiodogram/__init__.py
+++ b/ftperiodogram/__init__.py
@@ -1,4 +1,6 @@
 from .version import __version__
 
 from .modeler import FastTemplatePeriodogram, FastMultiTemplatePeriodogram
+from .multiband import (FastMultibandTemplatePeriodogram,
+                        MultibandTemplateModel, MultibandModelFitParams)
 from .template import Template

--- a/ftperiodogram/core.py
+++ b/ftperiodogram/core.py
@@ -88,7 +88,7 @@ def YM_MM_from_sums(cn, sn, sums):
     return YM, MM, AC
 
 
-def roots_from_YM_MM(YM, MM, AC, H, ybar, YY):
+def roots_from_YM_MM(YM, MM, AC, H, ybar, YY, positive_amplitude=False):
     r"""
     Find the optimal phase root of the ``YM``/``MM`` polynomials and reconstruct
     the best-fit template parameters and periodogram power.
@@ -111,6 +111,13 @@ def roots_from_YM_MM(YM, MM, AC, H, ybar, YY):
         Weighted mean used to reconstruct the offset ``theta_3``.
     YY : float
         Weighted variance used to normalize the power.
+    positive_amplitude : bool, optional (default False)
+        If True, restrict the root selection to roots that yield a non-negative
+        amplitude ``theta_1`` and return the best-fitting such root. This is the
+        constant-time positivity filter over the same root set (paper item
+        K.18); the multiband solver uses it. The default (False) leaves the
+        single-band behavior unchanged: the global power-maximizing root is
+        returned regardless of the sign of ``theta_1``.
 
     Returns
     -------
@@ -136,6 +143,15 @@ def roots_from_YM_MM(YM, MM, AC, H, ybar, YY):
 
     # Get periodogram values at each root
     pdg_phi = np.real(YM(roots) ** 2 /  MM(roots)) / YY
+
+    if positive_amplitude:
+        # K.18: among the roots, keep only those whose amplitude theta_1 >= 0,
+        # then pick the best-fitting one. A half-phase flip would NOT preserve
+        # the fitted curve for H > 1, so we filter the root set instead.
+        theta_1_all = np.real(np.power(roots, H) * YM(roots) / MM(roots))
+        positive = theta_1_all >= 0
+        if np.any(positive):
+            pdg_phi = np.where(positive, pdg_phi, -np.inf)
 
     # find root that maximizes periodogram
     i = np.argmax(pdg_phi)

--- a/ftperiodogram/core.py
+++ b/ftperiodogram/core.py
@@ -115,9 +115,12 @@ def roots_from_YM_MM(YM, MM, AC, H, ybar, YY, positive_amplitude=False):
         If True, restrict the root selection to roots that yield a non-negative
         amplitude ``theta_1`` and return the best-fitting such root. This is the
         constant-time positivity filter over the same root set (paper item
-        K.18); the multiband solver uses it. The default (False) leaves the
-        single-band behavior unchanged: the global power-maximizing root is
-        returned regardless of the sign of ``theta_1``.
+        K.18); the multiband solver uses it. If *no* root yields a non-negative
+        amplitude (the data anti-correlate with the template at every candidate
+        phase), the global power-maximizing root is returned as a fallback, so a
+        negative ``theta_1`` is still possible in that degenerate case. The
+        default (False) leaves the single-band behavior unchanged: the global
+        power-maximizing root is returned regardless of the sign of ``theta_1``.
 
     Returns
     -------

--- a/ftperiodogram/multiband.py
+++ b/ftperiodogram/multiband.py
@@ -369,12 +369,82 @@ def multiband_template_fit_from_sums(template_dict, per_band_sums, stats, mode,
         return MultibandModelFitParams(params_by_band, mode), float(power)
 
     if mode == 'shared_phase':
-        raise NotImplementedError(
-            "mode='shared_phase' (model B) is not implemented yet; it requires "
-            "a larger, separately-derived polynomial and is planned for a later "
-            "v0.2 commit. Use 'floating_offsets', 'sesar', or 'independent'.")
+        return _shared_phase_fit(template_dict, per_band_sums, stats)
 
     raise ValueError("Unknown mode {0!r}; must be one of {1}".format(mode, MODES))
+
+
+def _shared_phase_fit(template_dict, per_band_sums, stats):
+    r"""Solve model B (shared phase, per-band amplitude and offset) at one freq.
+
+    For a fixed shared phase :math:`\phi` each band fits independently, so the
+    total power is
+
+        F(phi) = sum_k W_k (P_YM^(k)(phi))^2 / P_MM^(k)(phi)
+
+    (normalized by the per-band-centered variance ``YY_combined``). Maximizing
+    over phi, after clearing the common denominator ``prod_l (P_MM^(l))^2``
+    (which is positive on the unit circle), gives the stationarity polynomial
+
+        G(phi) = sum_k W_k P_YM^(k) q_k prod_{l != k} (P_MM^(l))^2 = 0,
+        q_k = 2 P_MM^(k) (P_YM^(k))' - (P_MM^(k))' P_YM^(k),
+
+    of degree ``8 H K - 1`` -- a genuinely larger root problem than the
+    single-band case (cost grows as ``(H K)^3`` per frequency).
+
+    POSITIVITY: unlike the shared-amplitude modes, the phase here is shared, so
+    the per-band amplitudes cannot each be independently forced positive; this
+    routine returns the power-maximizing shared phase and reports the per-band
+    amplitudes as fitted (they are >= 0 for a genuine in-phase multiband signal,
+    but can be negative for a band that anti-correlates at the shared phase).
+    """
+    H = stats.H
+    bands = stats.bands
+
+    per_band = {band: pdg.YM_MM_from_sums(template_dict[band].c_n,
+                                          template_dict[band].s_n,
+                                          per_band_sums[band])
+                for band in bands}
+    PMM = {band: per_band[band][1] for band in bands}
+
+    G = None
+    for k in bands:
+        P_YM, P_MM, _ = per_band[k]
+        q = 2 * P_MM * P_YM.deriv() - P_MM.deriv() * P_YM
+        prod_others = pol.Polynomial([1.0 + 0j])
+        for l in bands:
+            if l != k:
+                prod_others = prod_others * (PMM[l] * PMM[l])
+        term = stats.W[k] * (P_YM * q * prod_others)
+        G = term if G is None else G + term
+
+    roots = G.roots()
+    roots = roots[np.absolute(roots) > 0]
+    roots /= np.absolute(roots)
+
+    # total power at each candidate shared phase
+    F = np.zeros(len(roots))
+    for k in bands:
+        P_YM, P_MM, _ = per_band[k]
+        F += stats.W[k] * np.real(P_YM(roots) ** 2 / P_MM(roots))
+
+    i = int(np.argmax(F))
+    best_phi = roots[i]
+    power = F[i] / stats.YY_combined
+
+    theta_2 = np.imag(np.log(best_phi)) % (2 * np.pi)
+    b = np.cos(theta_2)
+    sgn = np.sign(np.sin(theta_2))
+
+    params_by_band = {}
+    for k in bands:
+        P_YM, P_MM, AC_k = per_band[k]
+        theta_1_k = np.real(np.power(best_phi, H) * P_YM(best_phi) / P_MM(best_phi))
+        mbar_k = 2 * np.real(pol.Polynomial(np.concatenate(([0], AC_k)))(best_phi))
+        c_k = stats.ybar[k] - theta_1_k * mbar_k
+        params_by_band[k] = ModelFitParams(a=theta_1_k, b=b, c=c_k, sgn=sgn)
+
+    return MultibandModelFitParams(params_by_band, 'shared_phase'), float(power)
 
 
 def multiband_template_periodogram(t, y, bands, template_dict, freqs, dy=None,
@@ -456,10 +526,6 @@ class FastMultibandTemplatePeriodogram(object):
         if self.mode not in MODES:
             raise ValueError("Unknown mode {0!r}; must be one of {1}"
                              "".format(self.mode, MODES))
-        if self.mode == 'shared_phase':
-            raise NotImplementedError(
-                "mode='shared_phase' (model B) is not implemented yet; it is "
-                "planned for a later v0.2 commit.")
         if self.mode == 'sesar' and self.relative_offsets is None:
             raise ValueError("mode='sesar' requires relative_offsets="
                              "{band: lambda}.")

--- a/ftperiodogram/multiband.py
+++ b/ftperiodogram/multiband.py
@@ -113,10 +113,14 @@ class MultibandTemplateModel(object):
         return self.single_band_model(band)(np.asarray(t, dtype=float))
 
     def __call__(self, t, bands):
-        """Evaluate y_hat for flat arrays ``(t, bands)``, dispatching per band."""
+        """Evaluate y_hat for flat arrays ``(t, bands)``, dispatching per band.
+
+        Observations whose band was not present at fit time are returned as
+        ``nan`` (the model has no parameters for them).
+        """
         t = np.asarray(t, dtype=float)
         bands = np.asarray(bands)
-        out = np.empty(t.shape, dtype=float)
+        out = np.full(t.shape, np.nan, dtype=float)
         for band in self.parameters.params_by_band:
             mask = (bands == band)
             if np.any(mask):
@@ -315,26 +319,47 @@ def combine_band_summations(per_band_YM_MM, W, ybar, ybar_global, mode):
 # ----------------------------------------------------------------------
 # Per-frequency multiband solve (analog of core.template_fit_from_sums).
 # ----------------------------------------------------------------------
+def _mbar_at(AC, phi):
+    """Mean-template value ``2 Re(sum_n AC_n phi^n)`` at ``phi`` (offset recon)."""
+    return 2 * np.real(pol.Polynomial(np.concatenate(([0], AC)))(phi))
+
+
+def _per_band_YM_MM(template_dict, per_band_sums, bands):
+    """Build ``{band: (YM, MM, AC)}`` via :func:`core.YM_MM_from_sums` per band."""
+    return {band: pdg.YM_MM_from_sums(template_dict[band].c_n,
+                                      template_dict[band].s_n,
+                                      per_band_sums[band])
+            for band in bands}
+
+
+def _flat_model(stats, mode):
+    """Degenerate zero-amplitude, zero-power result for a flat (no-variance)
+    light curve, used when the relevant reference variance is zero."""
+    pbb = {band: ModelFitParams(a=0.0, b=1.0, c=stats.ybar[band], sgn=1.0)
+           for band in stats.bands}
+    return MultibandModelFitParams(pbb, mode), 0.0
+
+
 def multiband_template_fit_from_sums(template_dict, per_band_sums, stats, mode,
                                      relative_offsets=None):
     """Solve the multiband template fit at one frequency from precomputed sums.
 
-    Returns ``(MultibandModelFitParams, power)``. Always returns the
-    ``theta_1 >= 0`` solution (paper item K.18).
+    Returns ``(MultibandModelFitParams, power)``. For every mode except
+    ``shared_phase`` the better-fitting ``theta_1 >= 0`` solution is returned
+    when one exists (paper item K.18); ``shared_phase`` shares the phase across
+    bands and so reports per-band amplitudes as fitted.
     """
     H = stats.H
     bands = stats.bands
 
     if mode in ('floating_offsets', 'sesar'):
-        per_band_YM_MM = {band: pdg.YM_MM_from_sums(template_dict[band].c_n,
-                                                    template_dict[band].s_n,
-                                                    per_band_sums[band])
-                          for band in bands}
+        YY = stats.YY_global if mode == 'sesar' else stats.YY_combined
+        if YY <= 0:                       # flat light curve: nothing to detect
+            return _flat_model(stats, mode)
 
+        per_band_YM_MM = _per_band_YM_MM(template_dict, per_band_sums, bands)
         YM, MM, AC = combine_band_summations(per_band_YM_MM, stats.W, stats.ybar,
                                              stats.ybar_global, mode)
-
-        YY = stats.YY_global if mode == 'sesar' else stats.YY_combined
         shared, power, best_phi = pdg.roots_from_YM_MM(
             YM, MM, AC, H, stats.ybar_global, YY, positive_amplitude=True)
 
@@ -346,26 +371,30 @@ def multiband_template_fit_from_sums(template_dict, per_band_sums, stats, mode,
                 c_k = shared.c + relative_offsets[band]
             else:
                 # floating offset: theta_3^(k) = ybar_k - theta_1 * Mbar^(k)(phi)
-                mbar_k = 2 * np.real(pol.Polynomial(
-                    np.concatenate(([0], AC_k)))(best_phi))
-                c_k = stats.ybar[band] - shared.a * mbar_k
+                c_k = stats.ybar[band] - shared.a * _mbar_at(AC_k, best_phi)
             params_by_band[band] = ModelFitParams(a=shared.a, b=shared.b,
                                                   c=c_k, sgn=shared.sgn)
 
         return MultibandModelFitParams(params_by_band, mode), float(power)
 
     if mode == 'independent':
+        if stats.YY_combined <= 0:
+            return _flat_model(stats, mode)
+        per_band_YM_MM = _per_band_YM_MM(template_dict, per_band_sums, bands)
         params_by_band = {}
-        power = 0.0
+        explained = 0.0
         for band in bands:
-            YM_k, MM_k, AC_k = pdg.YM_MM_from_sums(template_dict[band].c_n,
-                                                  template_dict[band].s_n,
-                                                  per_band_sums[band])
+            YM_k, MM_k, AC_k = per_band_YM_MM[band]
             params_k, power_k, _ = pdg.roots_from_YM_MM(
                 YM_k, MM_k, AC_k, H, stats.ybar[band], stats.YY_per_band[band],
                 positive_amplitude=True)
             params_by_band[band] = params_k
-            power += stats.W[band] * power_k
+            # Accumulate explained variance and normalize once by the combined
+            # variance, so the reported power is the global fraction of variance
+            # explained -- comparable to the other modes. A plain W_k-weighted
+            # average of per-band powers would over-weight low-variance bands.
+            explained += stats.W[band] * power_k * stats.YY_per_band[band]
+        power = explained / stats.YY_combined
         return MultibandModelFitParams(params_by_band, mode), float(power)
 
     if mode == 'shared_phase':
@@ -401,10 +430,10 @@ def _shared_phase_fit(template_dict, per_band_sums, stats):
     H = stats.H
     bands = stats.bands
 
-    per_band = {band: pdg.YM_MM_from_sums(template_dict[band].c_n,
-                                          template_dict[band].s_n,
-                                          per_band_sums[band])
-                for band in bands}
+    if stats.YY_combined <= 0:            # flat light curve: nothing to detect
+        return _flat_model(stats, 'shared_phase')
+
+    per_band = _per_band_YM_MM(template_dict, per_band_sums, bands)
     PMM = {band: per_band[band][1] for band in bands}
 
     G = None
@@ -420,13 +449,21 @@ def _shared_phase_fit(template_dict, per_band_sums, stats):
 
     roots = G.roots()
     roots = roots[np.absolute(roots) > 0]
+    if len(roots) == 0:                   # no stationary phase: degenerate
+        return _flat_model(stats, 'shared_phase')
     roots /= np.absolute(roots)
 
-    # total power at each candidate shared phase
-    F = np.zeros(len(roots))
-    for k in bands:
-        P_YM, P_MM, _ = per_band[k]
-        F += stats.W[k] * np.real(P_YM(roots) ** 2 / P_MM(roots))
+    # total power at each candidate shared phase; guard against a root that is
+    # also (near) a root of some band's P_MM, which would make a term blow up.
+    with np.errstate(divide='ignore', invalid='ignore'):
+        F = np.zeros(len(roots))
+        for k in bands:
+            P_YM, P_MM, _ = per_band[k]
+            F += stats.W[k] * np.real(P_YM(roots) ** 2 / P_MM(roots))
+    finite = np.isfinite(F)
+    if not np.any(finite):
+        return _flat_model(stats, 'shared_phase')
+    F = np.where(finite, F, -np.inf)
 
     i = int(np.argmax(F))
     best_phi = roots[i]
@@ -440,8 +477,7 @@ def _shared_phase_fit(template_dict, per_band_sums, stats):
     for k in bands:
         P_YM, P_MM, AC_k = per_band[k]
         theta_1_k = np.real(np.power(best_phi, H) * P_YM(best_phi) / P_MM(best_phi))
-        mbar_k = 2 * np.real(pol.Polynomial(np.concatenate(([0], AC_k)))(best_phi))
-        c_k = stats.ybar[k] - theta_1_k * mbar_k
+        c_k = stats.ybar[k] - theta_1_k * _mbar_at(AC_k, best_phi)
         params_by_band[k] = ModelFitParams(a=theta_1_k, b=b, c=c_k, sgn=sgn)
 
     return MultibandModelFitParams(params_by_band, 'shared_phase'), float(power)
@@ -600,7 +636,8 @@ class FastMultibandTemplatePeriodogram(object):
         df = 1. / (baseline * samples_per_peak)
 
         if minimum_frequency is not None:
-            nf0 = min([1, np.floor(minimum_frequency / df)])
+            # start the grid at (or just above) the requested minimum frequency
+            nf0 = max(1, int(np.floor(minimum_frequency / df)))
         else:
             nf0 = 1
 

--- a/ftperiodogram/multiband.py
+++ b/ftperiodogram/multiband.py
@@ -483,6 +483,49 @@ def _shared_phase_fit(template_dict, per_band_sums, stats):
     return MultibandModelFitParams(params_by_band, 'shared_phase'), float(power)
 
 
+def compute_band_summations(t, y, bands, freqs, H, dy=None, mode=DEFAULT_MODE,
+                            relative_offsets=None, fast=True):
+    """Compute the per-band NFFT summations and per-band statistics.
+
+    The returned ``per_band_sumlists`` (one ``Summations`` per frequency, per
+    band) depend only on the data and ``(mode, relative_offsets, H)`` -- NOT on
+    the template shape -- so they can be computed once and reused across a whole
+    template catalog. Returns ``(per_band_sumlists, stats)``.
+    """
+    band_data, stats = _prepare_bands(t, y, bands, dy, mode,
+                                      relative_offsets, H)
+    freqs = np.asarray(freqs, dtype=float)
+
+    per_band_sumlists = OrderedDict()
+    for band, (t_k, y_k, w_k) in band_data.items():
+        if fast:
+            per_band_sumlists[band] = fast_summations(t_k, y_k, w_k, freqs, H)
+        else:
+            per_band_sumlists[band] = direct_summations(t_k, y_k, w_k, freqs, H)
+
+    return per_band_sumlists, stats
+
+
+def solve_over_frequencies(template_dict, per_band_sumlists, stats, nfreq,
+                           mode=DEFAULT_MODE, relative_offsets=None):
+    """Run the per-frequency multiband solve given precomputed per-band sums.
+
+    Pairs with :func:`compute_band_summations`; the template-dependent half of
+    the periodogram. Returns ``(powers, params_list)``.
+    """
+    bands = list(per_band_sumlists)
+    powers = np.empty(nfreq, dtype=float)
+    params_list = []
+    for i in range(nfreq):
+        per_band_sums = {band: per_band_sumlists[band][i] for band in bands}
+        mb_params, power = multiband_template_fit_from_sums(
+            template_dict, per_band_sums, stats, mode, relative_offsets)
+        powers[i] = power
+        params_list.append(mb_params)
+
+    return powers, params_list
+
+
 def multiband_template_periodogram(t, y, bands, template_dict, freqs, dy=None,
                                    mode=DEFAULT_MODE, relative_offsets=None,
                                    fast=True):
@@ -498,28 +541,12 @@ def multiband_template_periodogram(t, y, bands, template_dict, freqs, dy=None,
     :class:`MultibandModelFitParams` at each frequency.
     """
     H = len(next(iter(template_dict.values())).c_n)
-    band_data, stats = _prepare_bands(t, y, bands, dy, mode,
-                                      relative_offsets, H)
     freqs = np.asarray(freqs, dtype=float)
-
-    per_band_sumlists = {}
-    for band, (t_k, y_k, w_k) in band_data.items():
-        if fast:
-            per_band_sumlists[band] = fast_summations(t_k, y_k, w_k, freqs, H)
-        else:
-            per_band_sumlists[band] = direct_summations(t_k, y_k, w_k, freqs, H)
-
-    powers = np.empty(len(freqs), dtype=float)
-    params_list = []
-    for i in range(len(freqs)):
-        per_band_sums = {band: per_band_sumlists[band][i]
-                         for band in band_data}
-        mb_params, power = multiband_template_fit_from_sums(
-            template_dict, per_band_sums, stats, mode, relative_offsets)
-        powers[i] = power
-        params_list.append(mb_params)
-
-    return powers, params_list
+    per_band_sumlists, stats = compute_band_summations(
+        t, y, bands, freqs, H, dy=dy, mode=mode,
+        relative_offsets=relative_offsets, fast=fast)
+    return solve_over_frequencies(template_dict, per_band_sumlists, stats,
+                                  len(freqs), mode, relative_offsets)
 
 
 # ----------------------------------------------------------------------
@@ -659,18 +686,27 @@ class FastMultibandTemplatePeriodogram(object):
         self._validate_templates()
         self._validate_data()
 
-        kw = dict(dy=self.dy, mode=self.mode,
-                  relative_offsets=self.relative_offsets, fast=fast)
-
         if not self._is_catalog:
             powers, params = multiband_template_periodogram(
-                self.t, self.y, self.bands, self._template_dict, freqs, **kw)
+                self.t, self.y, self.bands, self._template_dict, freqs,
+                dy=self.dy, mode=self.mode,
+                relative_offsets=self.relative_offsets, fast=fast)
             return np.asarray(powers), params, None
+
+        # Catalog: the per-band NFFT summations are template-independent, so
+        # compute them ONCE and reuse them for every template-set (avoids an
+        # N-fold redundant NFFT for an N-template catalog).
+        nfreq = len(np.asarray(freqs))
+        H = len(next(iter(self._template_sets[0].values())).c_n)
+        per_band_sumlists, stats = compute_band_summations(
+            self.t, self.y, self.bands, freqs, H, dy=self.dy, mode=self.mode,
+            relative_offsets=self.relative_offsets, fast=fast)
 
         stack, param_sets = [], []
         for template_dict in self._template_sets:
-            pw, pl = multiband_template_periodogram(
-                self.t, self.y, self.bands, template_dict, freqs, **kw)
+            pw, pl = solve_over_frequencies(
+                template_dict, per_band_sumlists, stats, nfreq,
+                self.mode, self.relative_offsets)
             stack.append(np.asarray(pw))
             param_sets.append(pl)
         stack = np.array(stack)                       # (nsets, nfreq)

--- a/ftperiodogram/multiband.py
+++ b/ftperiodogram/multiband.py
@@ -497,10 +497,15 @@ class FastMultibandTemplatePeriodogram(object):
 
     Parameters
     ----------
-    templates : Template or dict {band: Template} or list of Template
-        A shared template shape, explicit per-band shapes, or a list aligned to
-        ``sorted(unique(bands))``. All band templates must share the harmonic
-        count ``H``.
+    templates : Template, dict {band: Template}, or list of those
+        A shared template shape (one ``Template`` for every band) or explicit
+        per-band shapes (a ``{band: Template}`` dict). A **list/tuple** is a
+        *catalog* of template-sets (each element a ``Template`` or a
+        ``{band: Template}`` dict); the periodogram then reports, at each
+        frequency, the maximum power over the sets, and records the winning set
+        index on ``best_model.template_set_index``. All templates share the
+        harmonic count ``H``. (Per-band assignment uses a dict; a top-level list
+        is always interpreted as a catalog.)
     mode : str, optional (default ``'floating_offsets'``)
         The sharing-hierarchy member; one of :data:`MODES`.
     relative_offsets : dict {band: float}, optional
@@ -519,7 +524,9 @@ class FastMultibandTemplatePeriodogram(object):
         self.t, self.y, self.bands, self.dy = None, None, None, None
         self.bands_ = None
         self.best_model = None
+        self._is_catalog = False
         self._template_dict = None
+        self._template_sets = None
 
     # -- validation -----------------------------------------------------
     def _validate_mode(self):
@@ -533,7 +540,14 @@ class FastMultibandTemplatePeriodogram(object):
     def _validate_templates(self):
         if self.templates is None:
             raise ValueError("No templates set.")
-        self._template_dict = build_template_set(self.templates, self.bands_)
+        if isinstance(self.templates, (list, tuple)):
+            self._is_catalog = True
+            self._template_sets = [build_template_set(s, self.bands_)
+                                   for s in self.templates]
+        else:
+            self._is_catalog = False
+            self._template_dict = build_template_set(self.templates,
+                                                     self.bands_)
 
     def _validate_data(self):
         if any(x is None for x in (self.t, self.y, self.bands)):
@@ -597,38 +611,63 @@ class FastMultibandTemplatePeriodogram(object):
 
         return df * (nf0 + np.arange(Nf))
 
-    def fit_model(self, freq):
-        """Best-fit :class:`MultibandTemplateModel` at a single frequency."""
+    def _run(self, freqs, fast):
+        """Compute powers + best params over a frequency array, handling both a
+        single template-set and a catalog (per-frequency max over sets).
+
+        Returns ``(powers, params_list, winning_set)`` where ``winning_set`` is
+        an int array of winning set indices for a catalog, else ``None``.
+        """
         self._validate_mode()
         self._validate_templates()
         self._validate_data()
-        _, params_list = multiband_template_periodogram(
-            self.t, self.y, self.bands, self._template_dict, [float(freq)],
-            dy=self.dy, mode=self.mode, relative_offsets=self.relative_offsets,
-            fast=False)
-        return MultibandTemplateModel(self._template_dict, frequency=float(freq),
-                                      parameters=params_list[0])
+
+        kw = dict(dy=self.dy, mode=self.mode,
+                  relative_offsets=self.relative_offsets, fast=fast)
+
+        if not self._is_catalog:
+            powers, params = multiband_template_periodogram(
+                self.t, self.y, self.bands, self._template_dict, freqs, **kw)
+            return np.asarray(powers), params, None
+
+        stack, param_sets = [], []
+        for template_dict in self._template_sets:
+            pw, pl = multiband_template_periodogram(
+                self.t, self.y, self.bands, template_dict, freqs, **kw)
+            stack.append(np.asarray(pw))
+            param_sets.append(pl)
+        stack = np.array(stack)                       # (nsets, nfreq)
+        winning_set = np.argmax(stack, axis=0)
+        powers = stack[winning_set, np.arange(stack.shape[1])]
+        params = [param_sets[winning_set[i]][i] for i in range(len(winning_set))]
+        return powers, params, winning_set
+
+    def _make_model(self, freq, params, set_index):
+        templates = (self._template_sets[set_index] if self._is_catalog
+                     else self._template_dict)
+        model = MultibandTemplateModel(templates, frequency=float(freq),
+                                       parameters=params)
+        if self._is_catalog:
+            model.template_set_index = int(set_index)
+        return model
+
+    def fit_model(self, freq):
+        """Best-fit :class:`MultibandTemplateModel` at a single frequency."""
+        powers, params, win = self._run([float(freq)], fast=False)
+        return self._make_model(freq, params[0], None if win is None else win[0])
 
     def autopower(self, save_best_model=True, fast=True, **kwargs):
         """Compute the multiband periodogram on the auto-determined grid.
 
         Returns ``(frequency, power)``.
         """
-        self._validate_mode()
-        self._validate_templates()
-        self._validate_data()
-
         frequency = self.autofrequency(**kwargs)
-        powers, params_list = multiband_template_periodogram(
-            self.t, self.y, self.bands, self._template_dict, frequency,
-            dy=self.dy, mode=self.mode, relative_offsets=self.relative_offsets,
-            fast=fast)
+        powers, params, win = self._run(frequency, fast)
 
         if save_best_model:
             i = int(np.argmax(powers))
-            self._save_best_model(MultibandTemplateModel(
-                self._template_dict, frequency=frequency[i],
-                parameters=params_list[i]))
+            self._save_best_model(self._make_model(
+                frequency[i], params[i], None if win is None else win[i]))
 
         return frequency, powers
 
@@ -636,24 +675,16 @@ class FastMultibandTemplatePeriodogram(object):
         """Compute multiband power at arbitrary (not necessarily gridded)
         frequencies. Output is reshaped to match the input.
         """
-        self._validate_mode()
-        self._validate_templates()
-        self._validate_data()
-
         frequency = np.asarray(frequency, dtype=float)
         shape = frequency.shape
         frequency = np.atleast_1d(frequency.ravel())
 
-        powers, params_list = multiband_template_periodogram(
-            self.t, self.y, self.bands, self._template_dict, frequency,
-            dy=self.dy, mode=self.mode, relative_offsets=self.relative_offsets,
-            fast=fast)
+        powers, params, win = self._run(frequency, fast)
 
         if save_best_model:
             i = int(np.argmax(powers))
-            self._save_best_model(MultibandTemplateModel(
-                self._template_dict, frequency=frequency[i],
-                parameters=params_list[i]))
+            self._save_best_model(self._make_model(
+                frequency[i], params[i], None if win is None else win[i]))
 
         return powers.reshape(shape)
 

--- a/ftperiodogram/multiband.py
+++ b/ftperiodogram/multiband.py
@@ -1,0 +1,616 @@
+"""
+Multiband Fast Template Periodogram.
+
+A drop-in sibling of :class:`ftperiodogram.modeler.FastTemplatePeriodogram` for
+time series observed in multiple photometric bands (e.g. ZTF *g/r/i*).  It
+implements the multiband "sharing hierarchy" derived in the thesis appendix
+(``chapter-appendices/multiband-template.tex``) and the paper's multiband
+notebooks, parametrized by what is held in common across bands:
+
+==================  =====================================  ====================
+``mode``            shared across bands                    free per band
+==================  =====================================  ====================
+``independent``     nothing (VanderPlas & Ivezic 2015)     amplitude, phase, offset
+``shared_phase``    phase                                  amplitude, offset
+``floating_offsets``  amplitude, phase                     offset  (**default**)
+``sesar``           amplitude, phase, offset; fixed lambda  -- (Sesar et al. 2016)
+==================  =====================================  ====================
+
+The two coupled-but-cheap members (``floating_offsets`` and ``sesar``) reduce to
+weighted averages of the per-band single-band quantities and reuse the
+single-band polynomial machinery in :mod:`ftperiodogram.core` verbatim, so they
+cost essentially the same as a single-band fit.
+
+NAMING: *Multiband* means multiple **bands**.  Do not confuse this with
+:class:`ftperiodogram.modeler.FastMultiTemplatePeriodogram`, which fits multiple
+candidate **templates** to a single band.
+
+DATA CONVENTION: flat ``(t, y, bands, dy)`` -- one row per observation with a
+band label -- matching ``astropy``/``gatspy`` ``LombScargleMultiband`` and a ZTF
+detection-table dump.  Each band's NFFT is computed on that band's own times,
+which are sorted internally; the *global* array need not be sorted (a documented
+relaxation of the single-band monotonic-``t`` contract).
+"""
+from __future__ import print_function
+
+from collections import namedtuple, OrderedDict
+
+import numpy as np
+import numpy.polynomial as pol
+
+from .template import Template
+from .utils import weights, ModelFitParams
+from .summations import fast_summations, direct_summations
+from .modeler import TemplateModel
+from . import core as pdg
+
+
+# Sharing-hierarchy members. The string values are the accepted ``mode=``.
+MODES = ('independent', 'shared_phase', 'floating_offsets', 'sesar')
+DEFAULT_MODE = 'floating_offsets'
+
+
+# ----------------------------------------------------------------------
+# Parameter / model containers (multiband analogs of ModelFitParams /
+# TemplateModel). The per-band parameters are ALWAYS stored as a
+# {band: ModelFitParams} dict -- a single source of truth, uniform across
+# modes, with no per-mode type switching.
+# ----------------------------------------------------------------------
+class MultibandModelFitParams(namedtuple('MultibandModelFitParams',
+                                          ['params_by_band', 'mode'])):
+    """Best-fit multiband parameters; the multiband analog of ``ModelFitParams``.
+
+    Parameters
+    ----------
+    params_by_band : dict {band: ModelFitParams}
+        The ordinary single-band ``ModelFitParams`` actually applied in each
+        band. For ``floating_offsets``/``sesar`` the amplitude (``a``) and phase
+        (``b``, ``sgn``) are identical across bands and only the offset (``c``)
+        differs; for ``independent``/``shared_phase`` they may all differ. The
+        offset ``c`` is the full additive constant in that band (for ``sesar``
+        it already includes the fixed relative offset ``lambda``).
+    mode : str
+        The sharing mode that produced these parameters.
+    """
+    __slots__ = ()
+
+    def single_band(self, band):
+        """Return the ordinary single-band ``ModelFitParams`` for one band."""
+        return self.params_by_band[band]
+
+
+class MultibandTemplateModel(object):
+    """Callable multiband best-fit model; the multiband analog of ``TemplateModel``.
+
+    Evaluates, in each band ``k``,
+
+        y_hat^(k)(t) = a^(k) * M^(k)(freq * (t - tau^(k))) + c^(k)
+
+    reconstructing ``tau`` from each band's ``(b, sgn)`` exactly as
+    :class:`ftperiodogram.modeler.TemplateModel` does.
+
+    Parameters
+    ----------
+    templates : dict {band: Template}
+        The resolved per-band templates.
+    frequency : float, optional (default 1.0)
+        Frequency of the signal.
+    parameters : MultibandModelFitParams
+        Best-fit multiband parameters.
+    """
+    def __init__(self, templates, frequency=1.0, parameters=None):
+        self.templates = templates
+        self.frequency = frequency
+        self.parameters = parameters
+
+    def single_band_model(self, band):
+        """Project to an ordinary single-band ``TemplateModel`` for one band."""
+        return TemplateModel(self.templates[band], frequency=self.frequency,
+                             parameters=self.parameters.single_band(band))
+
+    def predict_band(self, t, band):
+        """Evaluate the model light curve in a single band over times ``t``."""
+        return self.single_band_model(band)(np.asarray(t, dtype=float))
+
+    def __call__(self, t, bands):
+        """Evaluate y_hat for flat arrays ``(t, bands)``, dispatching per band."""
+        t = np.asarray(t, dtype=float)
+        bands = np.asarray(bands)
+        out = np.empty(t.shape, dtype=float)
+        for band in self.parameters.params_by_band:
+            mask = (bands == band)
+            if np.any(mask):
+                out[mask] = self.single_band_model(band)(t[mask])
+        return out
+
+
+# Frequency-independent per-band statistics, computed once per data set.
+_BandStats = namedtuple('_BandStats',
+                        ['bands', 'W', 'ybar', 'ybar_global',
+                         'YY_per_band', 'YY_combined', 'YY_global', 'H'])
+
+
+# ----------------------------------------------------------------------
+# Template-set normalization
+# ----------------------------------------------------------------------
+def build_template_set(templates, bands):
+    """Normalize a template specification into a ``{band: Template}`` dict.
+
+    Accepts a single shared ``Template``, a ``{band: Template}`` dict, or a
+    list/tuple aligned to ``sorted(unique(bands))``. Validates that every band
+    is covered and that all band templates share a common harmonic count ``H``.
+    """
+    band_labels = list(np.unique(bands))
+
+    if isinstance(templates, Template):
+        template_dict = {band: templates for band in band_labels}
+    elif isinstance(templates, dict):
+        template_dict = dict(templates)
+    elif isinstance(templates, (list, tuple)):
+        if len(templates) != len(band_labels):
+            raise ValueError("template list length ({0}) does not match the "
+                             "number of bands ({1})".format(len(templates),
+                                                            len(band_labels)))
+        template_dict = {band: tmpl
+                         for band, tmpl in zip(band_labels, templates)}
+    else:
+        raise TypeError("templates must be a Template, a {band: Template} dict, "
+                        "or a list/tuple of Templates")
+
+    harmonics = set()
+    for band in band_labels:
+        if band not in template_dict:
+            raise ValueError("No template provided for band {0!r}".format(band))
+        tmpl = template_dict[band]
+        if not isinstance(tmpl, Template):
+            raise ValueError("Template for band {0!r} is not a Template "
+                             "instance".format(band))
+        harmonics.add(len(tmpl.c_n))
+
+    if len(harmonics) > 1:
+        raise ValueError("All band templates must share the same number of "
+                         "harmonics (got {0})".format(sorted(harmonics)))
+
+    return template_dict
+
+
+# ----------------------------------------------------------------------
+# Band bookkeeping
+# ----------------------------------------------------------------------
+def _prepare_bands(t, y, bands, dy, mode, relative_offsets, H):
+    """Split flat data into per-band, time-sorted slices and summary statistics.
+
+    Returns ``(band_data, stats)`` where ``band_data`` maps each band to its
+    time-sorted ``(t_k, y_k, w_k)`` (with ``w_k`` renormalized to sum to 1
+    within the band, as required for the per-band NFFT) and ``stats`` is a
+    :class:`_BandStats` carrying the global/per-band means, variances, and band
+    weight totals ``W_k`` (which sum to 1 over all bands).
+
+    For ``mode='sesar'`` the fixed relative offsets ``lambda^(k)`` are subtracted
+    from ``y`` up front, so the means/variances/sums are all computed on the
+    offset-subtracted data.
+    """
+    t = np.asarray(t, dtype=float)
+    y = np.asarray(y, dtype=float)
+    bands = np.asarray(bands)
+    n = len(t)
+
+    if dy is None:
+        err = np.ones(n)
+    else:
+        err = np.broadcast_to(np.asarray(dy, dtype=float), (n,)).astype(float)
+    w_global = weights(err)
+
+    band_labels = list(np.unique(bands))
+
+    y_work = y.copy()
+    if mode == 'sesar':
+        if relative_offsets is None:
+            raise ValueError("mode='sesar' requires relative_offsets={band: "
+                             "lambda}; none were provided.")
+        for band in band_labels:
+            if band not in relative_offsets:
+                raise ValueError("relative_offsets is missing band {0!r}"
+                                 "".format(band))
+            y_work[bands == band] -= relative_offsets[band]
+
+    ybar_global = float(np.dot(w_global, y_work))
+    YY_global = float(np.dot(w_global, (y_work - ybar_global) ** 2))
+
+    band_data = OrderedDict()
+    W, ybar, YY_per_band = {}, {}, {}
+    for band in band_labels:
+        mask = (bands == band)
+        order = np.argsort(t[mask], kind='mergesort')
+        t_k = t[mask][order]
+        y_k = y_work[mask][order]
+        w_k_global = w_global[mask][order]
+
+        W_k = float(w_k_global.sum())
+        w_k = w_k_global / W_k                       # sum to 1 within the band
+        ybar_k = float(np.dot(w_k, y_k))
+        YY_k = float(np.dot(w_k, (y_k - ybar_k) ** 2))
+
+        band_data[band] = (t_k, y_k, w_k)
+        W[band] = W_k
+        ybar[band] = ybar_k
+        YY_per_band[band] = YY_k
+
+    # Combined (model-C) variance: deviations from per-band means.
+    YY_combined = float(sum(W[b] * YY_per_band[b] for b in band_labels))
+
+    stats = _BandStats(bands=band_labels, W=W, ybar=ybar,
+                       ybar_global=ybar_global, YY_per_band=YY_per_band,
+                       YY_combined=YY_combined, YY_global=YY_global, H=H)
+    return band_data, stats
+
+
+def _mean_template_poly(AC):
+    """Build the (phi**H-scaled) mean-template polynomial ``M_bar(phi)`` from AC."""
+    AC = np.asarray(AC)
+    coeffs = np.concatenate((np.conj(AC)[::-1], [0], AC)).astype(np.complex128)
+    return pol.Polynomial(coeffs)
+
+
+# ----------------------------------------------------------------------
+# The new multiband math: combining per-band YM/MM into YM'/MM'.
+# ----------------------------------------------------------------------
+def combine_band_summations(per_band_YM_MM, W, ybar, ybar_global, mode):
+    r"""Combine per-band ``YM``/``MM`` polynomials into the band-combined pair.
+
+    The per-band polynomials come from :func:`core.YM_MM_from_sums`, which
+    centers each band by its **own** weighted mean. For ``floating_offsets``
+    (model C) each band keeps its own offset, so the combination is simply the
+    ``W_k``-weighted average
+
+        YM' = sum_k W_k YM^(k),    MM' = sum_k W_k MM^(k).
+
+    For ``sesar`` (model D) there is a single shared offset, so the quantities
+    must be re-centered on the **global** mean (thesis lines 76-78):
+
+        YM' = sum_k W_k YM^(k) + sum_k W_k (ybar_k - ybar_global) Mbar^(k)
+        MM' = sum_k W_k MM^(k) + sum_k W_k (Mbar^(k))^2 - (sum_k W_k Mbar^(k))^2
+
+    where ``Mbar^(k)`` is band ``k``'s (phi**H-scaled) mean-template polynomial.
+    At ``K = 1`` (``ybar_k == ybar_global``, ``W_k == 1``) every correction term
+    vanishes and both modes collapse to the single-band ``YM``/``MM``.
+
+    Returns ``(YM, MM, AC)`` where ``AC`` is the ``W_k``-weighted mean-template
+    coefficient vector for the (global) offset reconstruction in the root tail.
+    """
+    bands = list(per_band_YM_MM)
+
+    YM = MM = None
+    AC = None
+    for band in bands:
+        YM_k, MM_k, AC_k = per_band_YM_MM[band]
+        wk = W[band]
+        YM = wk * YM_k if YM is None else YM + wk * YM_k
+        MM = wk * MM_k if MM is None else MM + wk * MM_k
+        AC_k = wk * np.asarray(AC_k)
+        AC = AC_k if AC is None else AC + AC_k
+
+    if mode == 'sesar':
+        YM_corr = MM_corr = Mbar_comb = None
+        for band in bands:
+            AC_k = per_band_YM_MM[band][2]
+            wk = W[band]
+            Mbar_k = _mean_template_poly(AC_k)
+
+            term = wk * ((ybar[band] - ybar_global) * Mbar_k)
+            YM_corr = term if YM_corr is None else YM_corr + term
+
+            sq = wk * (Mbar_k * Mbar_k)
+            MM_corr = sq if MM_corr is None else MM_corr + sq
+
+            wk_mbar = wk * Mbar_k
+            Mbar_comb = wk_mbar if Mbar_comb is None else Mbar_comb + wk_mbar
+
+        YM = YM + YM_corr
+        MM = MM + MM_corr - Mbar_comb * Mbar_comb
+
+    return YM, MM, AC
+
+
+# ----------------------------------------------------------------------
+# Per-frequency multiband solve (analog of core.template_fit_from_sums).
+# ----------------------------------------------------------------------
+def multiband_template_fit_from_sums(template_dict, per_band_sums, stats, mode,
+                                     relative_offsets=None):
+    """Solve the multiband template fit at one frequency from precomputed sums.
+
+    Returns ``(MultibandModelFitParams, power)``. Always returns the
+    ``theta_1 >= 0`` solution (paper item K.18).
+    """
+    H = stats.H
+    bands = stats.bands
+
+    if mode in ('floating_offsets', 'sesar'):
+        per_band_YM_MM = {band: pdg.YM_MM_from_sums(template_dict[band].c_n,
+                                                    template_dict[band].s_n,
+                                                    per_band_sums[band])
+                          for band in bands}
+
+        YM, MM, AC = combine_band_summations(per_band_YM_MM, stats.W, stats.ybar,
+                                             stats.ybar_global, mode)
+
+        YY = stats.YY_global if mode == 'sesar' else stats.YY_combined
+        shared, power, best_phi = pdg.roots_from_YM_MM(
+            YM, MM, AC, H, stats.ybar_global, YY, positive_amplitude=True)
+
+        params_by_band = {}
+        for band in bands:
+            AC_k = per_band_YM_MM[band][2]
+            if mode == 'sesar':
+                # single shared offset, plus the fixed relative offset lambda^(k)
+                c_k = shared.c + relative_offsets[band]
+            else:
+                # floating offset: theta_3^(k) = ybar_k - theta_1 * Mbar^(k)(phi)
+                mbar_k = 2 * np.real(pol.Polynomial(
+                    np.concatenate(([0], AC_k)))(best_phi))
+                c_k = stats.ybar[band] - shared.a * mbar_k
+            params_by_band[band] = ModelFitParams(a=shared.a, b=shared.b,
+                                                  c=c_k, sgn=shared.sgn)
+
+        return MultibandModelFitParams(params_by_band, mode), float(power)
+
+    if mode == 'independent':
+        params_by_band = {}
+        power = 0.0
+        for band in bands:
+            YM_k, MM_k, AC_k = pdg.YM_MM_from_sums(template_dict[band].c_n,
+                                                  template_dict[band].s_n,
+                                                  per_band_sums[band])
+            params_k, power_k, _ = pdg.roots_from_YM_MM(
+                YM_k, MM_k, AC_k, H, stats.ybar[band], stats.YY_per_band[band],
+                positive_amplitude=True)
+            params_by_band[band] = params_k
+            power += stats.W[band] * power_k
+        return MultibandModelFitParams(params_by_band, mode), float(power)
+
+    if mode == 'shared_phase':
+        raise NotImplementedError(
+            "mode='shared_phase' (model B) is not implemented yet; it requires "
+            "a larger, separately-derived polynomial and is planned for a later "
+            "v0.2 commit. Use 'floating_offsets', 'sesar', or 'independent'.")
+
+    raise ValueError("Unknown mode {0!r}; must be one of {1}".format(mode, MODES))
+
+
+def multiband_template_periodogram(t, y, bands, template_dict, freqs, dy=None,
+                                   mode=DEFAULT_MODE, relative_offsets=None,
+                                   fast=True):
+    """Multiband template periodogram over flat data; analog of
+    :func:`core.template_periodogram`.
+
+    This is the functional entry point (no class construction), suited to
+    batching many sources. Per-band NFFT summations are computed on each band's
+    own time-sorted samples, then the per-frequency multiband solve runs at each
+    frequency.
+
+    Returns ``(powers, params_list)``: a power array and the list of
+    :class:`MultibandModelFitParams` at each frequency.
+    """
+    H = len(next(iter(template_dict.values())).c_n)
+    band_data, stats = _prepare_bands(t, y, bands, dy, mode,
+                                      relative_offsets, H)
+    freqs = np.asarray(freqs, dtype=float)
+
+    per_band_sumlists = {}
+    for band, (t_k, y_k, w_k) in band_data.items():
+        if fast:
+            per_band_sumlists[band] = fast_summations(t_k, y_k, w_k, freqs, H)
+        else:
+            per_band_sumlists[band] = direct_summations(t_k, y_k, w_k, freqs, H)
+
+    powers = np.empty(len(freqs), dtype=float)
+    params_list = []
+    for i in range(len(freqs)):
+        per_band_sums = {band: per_band_sumlists[band][i]
+                         for band in band_data}
+        mb_params, power = multiband_template_fit_from_sums(
+            template_dict, per_band_sums, stats, mode, relative_offsets)
+        powers[i] = power
+        params_list.append(mb_params)
+
+    return powers, params_list
+
+
+# ----------------------------------------------------------------------
+# Public class (drop-in sibling of FastTemplatePeriodogram).
+# ----------------------------------------------------------------------
+class FastMultibandTemplatePeriodogram(object):
+    """Multiband template periodogram.
+
+    Fits a single (possibly per-band) template shape to multiband data under one
+    of the sharing modes in :data:`MODES`.
+
+    Parameters
+    ----------
+    templates : Template or dict {band: Template} or list of Template
+        A shared template shape, explicit per-band shapes, or a list aligned to
+        ``sorted(unique(bands))``. All band templates must share the harmonic
+        count ``H``.
+    mode : str, optional (default ``'floating_offsets'``)
+        The sharing-hierarchy member; one of :data:`MODES`.
+    relative_offsets : dict {band: float}, optional
+        Fixed per-band offsets ``lambda^(k)``; **required** for ``mode='sesar'``
+        and ignored otherwise.
+
+    Notes
+    -----
+    Distinct from :class:`ftperiodogram.modeler.FastMultiTemplatePeriodogram`,
+    which fits multiple candidate *templates* to a single band.
+    """
+    def __init__(self, templates=None, mode=DEFAULT_MODE, relative_offsets=None):
+        self.templates = templates
+        self.mode = mode
+        self.relative_offsets = relative_offsets
+        self.t, self.y, self.bands, self.dy = None, None, None, None
+        self.bands_ = None
+        self.best_model = None
+        self._template_dict = None
+
+    # -- validation -----------------------------------------------------
+    def _validate_mode(self):
+        if self.mode not in MODES:
+            raise ValueError("Unknown mode {0!r}; must be one of {1}"
+                             "".format(self.mode, MODES))
+        if self.mode == 'shared_phase':
+            raise NotImplementedError(
+                "mode='shared_phase' (model B) is not implemented yet; it is "
+                "planned for a later v0.2 commit.")
+        if self.mode == 'sesar' and self.relative_offsets is None:
+            raise ValueError("mode='sesar' requires relative_offsets="
+                             "{band: lambda}.")
+
+    def _validate_templates(self):
+        if self.templates is None:
+            raise ValueError("No templates set.")
+        self._template_dict = build_template_set(self.templates, self.bands_)
+
+    def _validate_data(self):
+        if any(x is None for x in (self.t, self.y, self.bands)):
+            raise ValueError("fit(t, y, bands, dy) must be called first.")
+        if not (len(self.t) == len(self.y) == len(self.bands)):
+            raise ValueError("t, y, and bands must have equal lengths.")
+        if self.dy is not None and np.ndim(self.dy) > 0 \
+                and len(self.dy) != len(self.t):
+            raise ValueError("dy must be scalar or the same length as t.")
+
+    # -- fitting --------------------------------------------------------
+    def fit(self, t, y, bands, dy=None):
+        """Store flat ``(t, y, bands, dy)``; record the sorted band labels.
+
+        Parameters
+        ----------
+        t, y : array_like
+            Flat observation times and values (in any global order; each band's
+            times are sorted internally for its NFFT).
+        bands : array_like
+            Per-observation band labels (a single hashable dtype, e.g.
+            ``'g'``/``'r'``/``'i'`` or integers).
+        dy : float or array_like, optional
+            Observational uncertainties; ``None`` or a scalar weights all
+            observations equally.
+
+        Returns
+        -------
+        self
+        """
+        self.t = np.asarray(t, dtype=float)
+        self.y = np.asarray(y, dtype=float)
+        self.bands = np.asarray(bands)
+        self.dy = dy
+        self.bands_ = np.unique(self.bands)
+        return self
+
+    def autofrequency(self, nyquist_factor=5, samples_per_peak=5,
+                      minimum_frequency=None, maximum_frequency=None):
+        """Determine a trial-frequency grid over the global observation baseline.
+
+        For irregularly-sampled data the average-Nyquist heuristic is not
+        meaningful; the recommended path is to set ``minimum_frequency`` and
+        ``maximum_frequency`` explicitly. ``nyquist_factor`` is retained only for
+        API parity with the single-band class.
+        """
+        baseline = self.t.max() - self.t.min()
+        n_samples = self.t.size
+
+        df = 1. / (baseline * samples_per_peak)
+
+        if minimum_frequency is not None:
+            nf0 = min([1, np.floor(minimum_frequency / df)])
+        else:
+            nf0 = 1
+
+        if maximum_frequency is not None:
+            Nf = int(np.ceil(maximum_frequency / df - nf0))
+        else:
+            Nf = int(0.5 * samples_per_peak * nyquist_factor * n_samples)
+
+        return df * (nf0 + np.arange(Nf))
+
+    def fit_model(self, freq):
+        """Best-fit :class:`MultibandTemplateModel` at a single frequency."""
+        self._validate_mode()
+        self._validate_templates()
+        self._validate_data()
+        _, params_list = multiband_template_periodogram(
+            self.t, self.y, self.bands, self._template_dict, [float(freq)],
+            dy=self.dy, mode=self.mode, relative_offsets=self.relative_offsets,
+            fast=False)
+        return MultibandTemplateModel(self._template_dict, frequency=float(freq),
+                                      parameters=params_list[0])
+
+    def autopower(self, save_best_model=True, fast=True, **kwargs):
+        """Compute the multiband periodogram on the auto-determined grid.
+
+        Returns ``(frequency, power)``.
+        """
+        self._validate_mode()
+        self._validate_templates()
+        self._validate_data()
+
+        frequency = self.autofrequency(**kwargs)
+        powers, params_list = multiband_template_periodogram(
+            self.t, self.y, self.bands, self._template_dict, frequency,
+            dy=self.dy, mode=self.mode, relative_offsets=self.relative_offsets,
+            fast=fast)
+
+        if save_best_model:
+            i = int(np.argmax(powers))
+            self._save_best_model(MultibandTemplateModel(
+                self._template_dict, frequency=frequency[i],
+                parameters=params_list[i]))
+
+        return frequency, powers
+
+    def power(self, frequency, save_best_model=True, fast=False):
+        """Compute multiband power at arbitrary (not necessarily gridded)
+        frequencies. Output is reshaped to match the input.
+        """
+        self._validate_mode()
+        self._validate_templates()
+        self._validate_data()
+
+        frequency = np.asarray(frequency, dtype=float)
+        shape = frequency.shape
+        frequency = np.atleast_1d(frequency.ravel())
+
+        powers, params_list = multiband_template_periodogram(
+            self.t, self.y, self.bands, self._template_dict, frequency,
+            dy=self.dy, mode=self.mode, relative_offsets=self.relative_offsets,
+            fast=fast)
+
+        if save_best_model:
+            i = int(np.argmax(powers))
+            self._save_best_model(MultibandTemplateModel(
+                self._template_dict, frequency=frequency[i],
+                parameters=params_list[i]))
+
+        return powers.reshape(shape)
+
+    def _save_best_model(self, model, overwrite=False):
+        if overwrite or self.best_model is None:
+            self.best_model = model
+            return
+        # keep whichever model better fits the data
+        y_fit = model(self.t, self.bands)
+        y_best = self.best_model(self.t, self.bands)
+        if _power_from_fit(self.y, self.dy, y_fit) > \
+                _power_from_fit(self.y, self.dy, y_best):
+            self.best_model = model
+
+
+def _power_from_fit(y, dy, yfit):
+    """Global unbiased-power of a fit, used only to break ties between saved
+    models (mirrors ``modeler.power_from_fit``)."""
+    n = len(y)
+    err = np.ones(n) if dy is None else \
+        np.broadcast_to(np.asarray(dy, dtype=float), (n,)).astype(float)
+    w = weights(err)
+    ybar = np.dot(w, y)
+    chi2_0 = np.dot(w, (y - ybar) ** 2)
+    chi2 = np.dot(w, (y - yfit) ** 2)
+    return 1. - (chi2 / chi2_0)

--- a/ftperiodogram/tests/test_multiband.py
+++ b/ftperiodogram/tests/test_multiband.py
@@ -126,8 +126,10 @@ def _brute_power(t, y, bands, dy, template, freq, mode, relative_offsets=None,
         return np.dot(w, resid ** 2), beta[0]      # beta[0] is the amplitude
 
     if mode == 'independent':
-        # each band independently; combine W_k-weighted powers
-        power = 0.0
+        # each band independently; combine as the global fraction of variance
+        # explained (sum_k W_k (YY_k - chi2_k) / sum_k W_k YY_k).
+        explained = 0.0
+        YY_C = 0.0
         for k in band_labels:
             m = bands == k
             wk = w[m] / w[m].sum()
@@ -135,6 +137,7 @@ def _brute_power(t, y, bands, dy, template, freq, mode, relative_offsets=None,
             tk = t[m]
             ybark = np.dot(wk, yk)
             chi2_0_k = np.dot(wk, (yk - ybark) ** 2)
+            Wk = w[m].sum()
 
             def chi2_amp_k(ph, tk=tk, yk=yk, wk=wk):
                 Mv = template((freq * tk - ph) % 1.0)
@@ -144,8 +147,9 @@ def _brute_power(t, y, bands, dy, template, freq, mode, relative_offsets=None,
                 return np.dot(wk, (yk - X @ beta) ** 2), beta[0]
 
             best = _scan_and_refine(chi2_amp_k, nphase=nphase)
-            power += w[m].sum() * (1 - best / chi2_0_k)
-        return power
+            explained += Wk * (chi2_0_k - best)
+            YY_C += Wk * chi2_0_k
+        return explained / YY_C
 
     best = _scan_and_refine(chi2_amp_shared, nphase=nphase)
     return 1 - best / chi2_0
@@ -452,8 +456,6 @@ def test_catalog_picks_better_template():
     other = _make_template(nharmonics=3, seed=99)  # a different shape
     sets = [other, TEMPLATE]
 
-    fmt = dict(mode='floating_offsets', minimum_frequency=0.05,
-               maximum_frequency=0.30)
     p_each = []
     for tmpl in sets:
         mb = FastMultibandTemplatePeriodogram(tmpl, mode='floating_offsets')
@@ -488,6 +490,45 @@ def test_missing_band_template_raises():
     mb.fit(t, y, bands, dy)
     with pytest.raises(ValueError):
         mb.autopower()
+
+
+@pytest.mark.parametrize('mode', ['floating_offsets', 'sesar', 'independent',
+                                  'shared_phase'])
+def test_flat_lightcurve_is_zero_power_not_nan(mode):
+    # a perfectly flat (zero-variance) source has nothing to detect; the
+    # periodogram must return finite, zero power rather than nan/inf or crash.
+    rng = np.random.RandomState(3)
+    n = 60
+    t = np.sort(rng.rand(n) * 50)
+    bands = np.array([0, 1, 2] * (n // 3))[:n]
+    y = np.full(n, 7.0)                # constant in every band
+    dy = np.full(n, 0.1)
+    kw = dict(relative_offsets={0: 0.0, 1: 0.0, 2: 0.0}) if mode == 'sesar' else {}
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode=mode, **kw)
+    mb.fit(t, y, bands, dy)
+    f, p = mb.autopower(minimum_frequency=0.05, maximum_frequency=0.30)
+    assert np.all(np.isfinite(p))
+    assert np.allclose(p, 0.0, atol=1e-9)
+
+
+def test_autofrequency_honors_minimum_frequency():
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0, 0.3))
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='floating_offsets')
+    mb.fit(t, y, bands, dy)
+    f, p = mb.autopower(minimum_frequency=2.0, maximum_frequency=4.0)
+    df = f[1] - f[0]
+    # grid starts at the nearest point at/just below min_freq (was ~0 before fix)
+    assert 2.0 - df <= f.min() <= 2.0 + df
+
+
+def test_predict_unseen_band_is_nan():
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0, 0.3))
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='floating_offsets')
+    mb.fit(t, y, bands, dy)
+    mb.autopower(minimum_frequency=0.05, maximum_frequency=0.30)
+    # band label 99 was never fit -> nan, not uninitialized garbage
+    out = mb.best_model(np.array([1.0, 2.0]), np.array([0, 99]))
+    assert np.isfinite(out[0]) and np.isnan(out[1])
 
 
 def test_mismatched_harmonics_raises():

--- a/ftperiodogram/tests/test_multiband.py
+++ b/ftperiodogram/tests/test_multiband.py
@@ -1,0 +1,380 @@
+"""Tests for the multiband fast template periodogram (ftperiodogram.multiband).
+
+The decisive test is the K>=2 brute-force comparison: it is the only check that
+can tell the floating-offsets (C) and sesar (D) models apart, since at K=1 they
+both collapse to the single-band path. The brute force is an independent oracle
+(fine phase scan + weighted least squares + local refinement), not a
+reimplementation of the polynomial solver.
+"""
+import numpy as np
+import numpy.polynomial as pol
+import pytest
+from scipy.optimize import minimize_scalar
+
+from ftperiodogram.template import Template
+from ftperiodogram.modeler import FastTemplatePeriodogram
+from ftperiodogram.utils import weights
+from ftperiodogram import core, summations
+from ftperiodogram.multiband import (FastMultibandTemplatePeriodogram,
+                                     MultibandTemplateModel,
+                                     MultibandModelFitParams,
+                                     multiband_template_periodogram,
+                                     build_template_set)
+
+
+# ----------------------------------------------------------------------
+# Fixtures / helpers
+# ----------------------------------------------------------------------
+def _make_template(nharmonics=3, seed=0):
+    rng = np.random.RandomState(seed)
+    n = 64
+    ph = np.arange(n) / n
+    y = (np.cos(2 * np.pi * ph) + 0.4 * np.cos(2 * np.pi * 2 * ph + 0.7)
+         + 0.2 * np.sin(2 * np.pi * 3 * ph))
+    return Template.from_sampled(y, nharmonics=nharmonics)
+
+
+def _simulate(template, f0=0.123, amp=2.0, band_offsets=(0.0,), n_per_band=60,
+              noise=0.03, seed=1):
+    """Simulate shared-amplitude, shared-phase multiband data with per-band
+    constant offsets (mean magnitudes)."""
+    rng = np.random.RandomState(seed)
+    t, y, bands, dy = [], [], [], []
+    for k, off in enumerate(band_offsets):
+        tk = np.sort(rng.rand(n_per_band) * 80)
+        sigk = noise * (1 + 0.5 * k)
+        yk = amp * template((f0 * tk) % 1.0) + off + sigk * rng.randn(n_per_band)
+        t.append(tk)
+        y.append(yk)
+        bands.append(np.full(n_per_band, k, dtype=int))
+        dy.append(np.full(n_per_band, sigk))
+    # interleave so the global array is NOT sorted (exercises per-band sorting)
+    t = np.concatenate(t)
+    y = np.concatenate(y)
+    bands = np.concatenate(bands)
+    dy = np.concatenate(dy)
+    order = np.random.RandomState(seed + 7).permutation(len(t))
+    return t[order], y[order], bands[order], dy[order]
+
+
+def _global_weights(dy, n):
+    err = np.ones(n) if dy is None else \
+        np.broadcast_to(np.asarray(dy, float), (n,)).astype(float)
+    return weights(err)
+
+
+def _single_band_positive_power(t, y, dy, template, freqs):
+    """Single-band power computed WITH the positivity filter (the reference the
+    multiband K=1 path must match exactly)."""
+    w = weights(dy)
+    ybar = np.dot(w, y)
+    YY = np.dot(w, (y - ybar) ** 2)
+    sums = summations.direct_summations(t, y, w, freqs, len(template.c_n))
+    H = len(template.c_n)
+    out = np.empty(len(freqs))
+    for i, s in enumerate(sums):
+        YM, MM, AC = core.YM_MM_from_sums(template.c_n, template.s_n, s)
+        _, pw, _ = core.roots_from_YM_MM(YM, MM, AC, H, ybar, YY,
+                                         positive_amplitude=True)
+        out[i] = pw
+    return out
+
+
+def _brute_power(t, y, bands, dy, template, freq, mode, relative_offsets=None,
+                 nphase=2000):
+    """Independent brute-force multiband power at a single frequency.
+
+    Scans the phase on a fine grid, solving a weighted linear least squares for
+    the (shared/per-band) amplitudes and offsets at each phase, then refines the
+    best phase. Enforces the same positivity (theta_1 >= 0) constraint as the
+    FTP solver: the maximum is taken only over phases yielding a non-negative
+    amplitude. Returns the maximized power 1 - chi2/chi2_0.
+    """
+    n = len(t)
+    w = _global_weights(dy, n)
+    band_labels = np.unique(bands)
+
+    y_work = y.astype(float).copy()
+    if mode == 'sesar':
+        for k in band_labels:
+            y_work[bands == k] -= relative_offsets[k]
+
+    # reference chi2_0
+    if mode in ('floating_offsets', 'independent'):
+        chi2_0 = 0.0
+        for k in band_labels:
+            m = bands == k
+            ybark = np.dot(w[m], y_work[m]) / w[m].sum()
+            chi2_0 += np.dot(w[m], (y_work[m] - ybark) ** 2)
+    else:  # sesar -> single global mean
+        ybar_g = np.dot(w, y_work)
+        chi2_0 = np.dot(w, (y_work - ybar_g) ** 2)
+
+    def design(ph):
+        Mvals = template((freq * t - ph) % 1.0)
+        if mode == 'sesar':
+            return np.column_stack([Mvals, np.ones(n)])
+        # floating_offsets: shared amplitude, per-band offsets
+        cols = [Mvals] + [(bands == k).astype(float) for k in band_labels]
+        return np.column_stack(cols)
+
+    def chi2_amp_shared(ph):
+        X = design(ph)
+        XtW = X.T * w
+        beta = np.linalg.solve(XtW @ X, XtW @ y_work)
+        resid = y_work - X @ beta
+        return np.dot(w, resid ** 2), beta[0]      # beta[0] is the amplitude
+
+    if mode == 'independent':
+        # each band independently; combine W_k-weighted powers
+        power = 0.0
+        for k in band_labels:
+            m = bands == k
+            wk = w[m] / w[m].sum()
+            yk = y_work[m]
+            tk = t[m]
+            ybark = np.dot(wk, yk)
+            chi2_0_k = np.dot(wk, (yk - ybark) ** 2)
+
+            def chi2_amp_k(ph, tk=tk, yk=yk, wk=wk):
+                Mv = template((freq * tk - ph) % 1.0)
+                X = np.column_stack([Mv, np.ones(len(tk))])
+                XtW = X.T * wk
+                beta = np.linalg.solve(XtW @ X, XtW @ yk)
+                return np.dot(wk, (yk - X @ beta) ** 2), beta[0]
+
+            best = _scan_and_refine(chi2_amp_k, nphase=nphase)
+            power += w[m].sum() * (1 - best / chi2_0_k)
+        return power
+
+    best = _scan_and_refine(chi2_amp_shared, nphase=nphase)
+    return 1 - best / chi2_0
+
+
+def _scan_and_refine(chi2_amp_fn, nphase=2000):
+    """Minimize chi2 over phase subject to amplitude >= 0.
+
+    ``chi2_amp_fn(ph)`` returns ``(chi2, amplitude)``.
+    """
+    grid = np.linspace(0, 1, nphase, endpoint=False)
+    out = [chi2_amp_fn(p) for p in grid]
+    chi2s = np.array([o[0] for o in out])
+    amps = np.array([o[1] for o in out])
+    masked = np.where(amps >= 0, chi2s, np.inf)
+    i = int(np.argmin(masked))
+    best = masked[i]
+
+    lo = grid[(i - 1) % nphase]
+    hi = grid[(i + 1) % nphase]
+    if lo < hi:
+        def obj(ph):
+            c, a = chi2_amp_fn(ph)
+            return c if a >= 0 else np.inf
+        res = minimize_scalar(obj, bounds=(lo, hi), method='bounded')
+        if res.fun < best:
+            best = res.fun
+    return best
+
+
+TEMPLATE = _make_template()
+FREQS = np.linspace(0.05, 0.30, 300)
+
+
+# ----------------------------------------------------------------------
+# K = 1 exact reduction to the single band path
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize('mode', ['floating_offsets', 'sesar', 'independent'])
+def test_k1_reduces_to_single_band(mode):
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0,))
+    ref = _single_band_positive_power(t, y, dy, TEMPLATE, FREQS)
+
+    kw = dict(relative_offsets={0: 0.0}) if mode == 'sesar' else {}
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode=mode, **kw)
+    mb.fit(t, y, bands, dy)
+    power = mb.power(FREQS)
+
+    assert np.allclose(power, ref, atol=1e-9), \
+        "K=1 %s deviates from single-band(+positivity) by %.2e" % (
+            mode, np.max(np.abs(power - ref)))
+
+
+def test_k1_single_band_params_roundtrip():
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0,))
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='floating_offsets')
+    mb.fit(t, y, bands, dy)
+    f, p = mb.autopower()
+    sb_params = mb.best_model.parameters.single_band(0)
+    # the single-band projection is an ordinary ModelFitParams
+    from ftperiodogram.utils import ModelFitParams
+    assert isinstance(sb_params, ModelFitParams)
+    assert sb_params.a >= 0
+
+
+# ----------------------------------------------------------------------
+# K >= 2 brute-force validation (the decisive test)
+# ----------------------------------------------------------------------
+def test_k2_floating_offsets_matches_brute_force():
+    offs = (0.0, -0.6, 0.4)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs)
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='floating_offsets')
+    mb.fit(t, y, bands, dy)
+    for f in (0.123, 0.0917, 0.2013):
+        p_ftp = float(mb.power(f))
+        p_bf = _brute_power(t, y, bands, dy, TEMPLATE, f, 'floating_offsets')
+        assert abs(p_ftp - p_bf) < 2e-3, \
+            "C: f=%.4f ftp=%.5f brute=%.5f" % (f, p_ftp, p_bf)
+
+
+def test_k2_sesar_matches_brute_force():
+    offs = (0.0, -0.6, 0.4)
+    lam = {0: 0.0, 1: -0.6, 2: 0.4}      # correct relative offsets
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs)
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='sesar',
+                                          relative_offsets=lam)
+    mb.fit(t, y, bands, dy)
+    for f in (0.123, 0.0917, 0.2013):
+        p_ftp = float(mb.power(f))
+        p_bf = _brute_power(t, y, bands, dy, TEMPLATE, f, 'sesar',
+                            relative_offsets=lam)
+        assert abs(p_ftp - p_bf) < 2e-3, \
+            "D: f=%.4f ftp=%.5f brute=%.5f" % (f, p_ftp, p_bf)
+
+
+def test_k2_independent_matches_brute_force():
+    offs = (0.0, -0.6, 0.4)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs)
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='independent')
+    mb.fit(t, y, bands, dy)
+    for f in (0.123, 0.0917):
+        p_ftp = float(mb.power(f))
+        p_bf = _brute_power(t, y, bands, dy, TEMPLATE, f, 'independent')
+        assert abs(p_ftp - p_bf) < 2e-3, \
+            "A: f=%.4f ftp=%.5f brute=%.5f" % (f, p_ftp, p_bf)
+
+
+def test_C_and_D_are_not_conflated():
+    """With offset per-band means and WRONG (zero) relative offsets, the sesar
+    model (D) must fit worse than floating-offsets (C). If the two were
+    implemented identically (the bug all critics flagged), the powers would be
+    equal."""
+    offs = (0.0, -0.8, 0.5)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs)
+
+    c = FastMultibandTemplatePeriodogram(TEMPLATE, mode='floating_offsets')
+    c.fit(t, y, bands, dy)
+    d = FastMultibandTemplatePeriodogram(
+        TEMPLATE, mode='sesar', relative_offsets={0: 0.0, 1: 0.0, 2: 0.0})
+    d.fit(t, y, bands, dy)
+
+    pc = float(c.power(0.123))
+    pd = float(d.power(0.123))
+    assert pc > pd + 0.05, "C (%.4f) should clearly beat misspecified D (%.4f)" % (pc, pd)
+
+
+def test_sesar_correct_offsets_recovers_signal():
+    offs = (0.0, -0.8, 0.5)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs)
+    d = FastMultibandTemplatePeriodogram(
+        TEMPLATE, mode='sesar', relative_offsets={0: 0.0, 1: -0.8, 2: 0.5})
+    d.fit(t, y, bands, dy)
+    f, p = d.autopower(minimum_frequency=0.05, maximum_frequency=0.30)
+    assert abs(f[np.argmax(p)] - 0.123) < 1e-3
+    assert p.max() > 0.9
+
+
+# ----------------------------------------------------------------------
+# Positivity (K.18)
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize('mode', ['floating_offsets', 'sesar', 'independent'])
+def test_amplitudes_are_nonnegative(mode):
+    offs = (0.0, -0.6, 0.4)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs)
+    kw = dict(relative_offsets={0: 0.0, 1: -0.6, 2: 0.4}) if mode == 'sesar' else {}
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode=mode, **kw)
+    mb.fit(t, y, bands, dy)
+    _, params_list = multiband_template_periodogram(
+        t, y, bands, build_template_set(TEMPLATE, bands), FREQS, dy=dy,
+        mode=mode, relative_offsets=kw.get('relative_offsets'), fast=False)
+    for mbp in params_list:
+        for band, pars in mbp.params_by_band.items():
+            assert pars.a >= 0, "negative amplitude in band %r" % band
+
+
+# ----------------------------------------------------------------------
+# fast (NFFT) vs direct summations
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize('mode', ['floating_offsets', 'sesar', 'independent'])
+def test_fast_matches_direct(mode):
+    offs = (0.0, -0.6, 0.4)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs)
+    kw = dict(relative_offsets={0: 0.0, 1: -0.6, 2: 0.4}) if mode == 'sesar' else {}
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode=mode, **kw)
+    mb.fit(t, y, bands, dy)
+    f_fast, p_fast = mb.autopower(fast=True, minimum_frequency=0.05,
+                                  maximum_frequency=0.30)
+    _, p_dir = mb.autopower(fast=False, minimum_frequency=0.05,
+                            maximum_frequency=0.30)
+    assert np.allclose(p_fast, p_dir, atol=1e-4), \
+        "fast vs direct max|diff| = %.2e" % np.max(np.abs(p_fast - p_dir))
+
+
+# ----------------------------------------------------------------------
+# Model object
+# ----------------------------------------------------------------------
+def test_model_predicts_per_band_offsets():
+    offs = (0.0, -0.8, 0.5)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs, noise=0.01)
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='floating_offsets')
+    mb.fit(t, y, bands, dy)
+    mb.autopower(minimum_frequency=0.05, maximum_frequency=0.30)
+    model = mb.best_model
+    yhat = model(t, bands)
+    # a good fit at the recovered period should track the data
+    assert np.corrcoef(yhat, y)[0, 1] > 0.95
+    # single-band projection agrees with the masked multiband evaluation
+    for k in np.unique(bands):
+        m = bands == k
+        assert np.allclose(model.predict_band(t[m], k), yhat[m])
+
+
+# ----------------------------------------------------------------------
+# Error / validation paths
+# ----------------------------------------------------------------------
+def test_sesar_without_offsets_raises():
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0, 0.3))
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='sesar')
+    mb.fit(t, y, bands, dy)
+    with pytest.raises(ValueError):
+        mb.autopower()
+
+
+def test_shared_phase_raises_not_implemented():
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0, 0.3))
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='shared_phase')
+    mb.fit(t, y, bands, dy)
+    with pytest.raises(NotImplementedError):
+        mb.autopower()
+
+
+def test_unknown_mode_raises():
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0, 0.3))
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='nonsense')
+    mb.fit(t, y, bands, dy)
+    with pytest.raises(ValueError):
+        mb.autopower()
+
+
+def test_missing_band_template_raises():
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0, 0.3))
+    mb = FastMultibandTemplatePeriodogram({0: TEMPLATE}, mode='floating_offsets')
+    mb.fit(t, y, bands, dy)
+    with pytest.raises(ValueError):
+        mb.autopower()
+
+
+def test_mismatched_harmonics_raises():
+    t2 = _make_template(nharmonics=2)
+    t3 = _make_template(nharmonics=3)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0, 0.3))
+    with pytest.raises(ValueError):
+        build_template_set({0: t2, 1: t3}, bands)

--- a/ftperiodogram/tests/test_multiband.py
+++ b/ftperiodogram/tests/test_multiband.py
@@ -431,6 +431,49 @@ def test_sesar_without_offsets_raises():
         mb.autopower()
 
 
+def test_catalog_single_element_equals_single_set():
+    offs = (0.0, -0.6, 0.4)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs)
+    single = FastMultibandTemplatePeriodogram(TEMPLATE, mode='floating_offsets')
+    single.fit(t, y, bands, dy)
+    f1, p1 = single.autopower(minimum_frequency=0.05, maximum_frequency=0.30)
+
+    catalog = FastMultibandTemplatePeriodogram([TEMPLATE], mode='floating_offsets')
+    catalog.fit(t, y, bands, dy)
+    f2, p2 = catalog.autopower(minimum_frequency=0.05, maximum_frequency=0.30)
+
+    assert np.allclose(p1, p2)
+    assert catalog.best_model.template_set_index == 0
+
+
+def test_catalog_picks_better_template():
+    offs = (0.0, -0.6, 0.4)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs)
+    other = _make_template(nharmonics=3, seed=99)  # a different shape
+    sets = [other, TEMPLATE]
+
+    fmt = dict(mode='floating_offsets', minimum_frequency=0.05,
+               maximum_frequency=0.30)
+    p_each = []
+    for tmpl in sets:
+        mb = FastMultibandTemplatePeriodogram(tmpl, mode='floating_offsets')
+        mb.fit(t, y, bands, dy)
+        p_each.append(mb.autopower(minimum_frequency=0.05,
+                                   maximum_frequency=0.30)[1])
+    p_each = np.array(p_each)
+
+    catalog = FastMultibandTemplatePeriodogram(sets, mode='floating_offsets')
+    catalog.fit(t, y, bands, dy)
+    f, p = catalog.autopower(minimum_frequency=0.05, maximum_frequency=0.30)
+
+    # the catalog reports the per-frequency max over sets
+    assert np.allclose(p, p_each.max(axis=0))
+    # and records the argmax set at the recovered peak
+    pk = int(np.argmax(p))
+    assert catalog.best_model.template_set_index == int(np.argmax(p_each[:, pk]))
+    assert abs(f[pk] - 0.123) < 1e-3
+
+
 def test_unknown_mode_raises():
     t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0, 0.3))
     mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='nonsense')

--- a/ftperiodogram/tests/test_multiband.py
+++ b/ftperiodogram/tests/test_multiband.py
@@ -151,6 +151,51 @@ def _brute_power(t, y, bands, dy, template, freq, mode, relative_offsets=None,
     return 1 - best / chi2_0
 
 
+def _brute_power_shared_phase(t, y, bands, dy, template, freq, nphase=2000):
+    """Brute-force model-B power: scan a SHARED phase, per-band independent
+    linear fits, combine W_k-weighted explained variance. No positivity
+    constraint (model B does not enforce per-band positivity)."""
+    n = len(t)
+    w = _global_weights(dy, n)
+    band_labels = np.unique(bands)
+
+    # per-band within-band weights, means, variances, weight totals
+    info = {}
+    YY_C = 0.0
+    for k in band_labels:
+        m = bands == k
+        wk = w[m] / w[m].sum()
+        yk = y[m].astype(float)
+        ybark = np.dot(wk, yk)
+        YYk = np.dot(wk, (yk - ybark) ** 2)
+        info[k] = (t[m], yk, wk, w[m].sum())
+        YY_C += w[m].sum() * YYk
+
+    def neg_power(ph):
+        explained = 0.0
+        for k in band_labels:
+            tk, yk, wk, Wk = info[k]
+            X = np.column_stack([template((freq * tk - ph) % 1.0),
+                                 np.ones(len(tk))])
+            XtW = X.T * wk
+            beta = np.linalg.solve(XtW @ X, XtW @ yk)
+            chi2_k = np.dot(wk, (yk - X @ beta) ** 2)
+            ybark = np.dot(wk, yk)
+            YYk = np.dot(wk, (yk - ybark) ** 2)
+            explained += Wk * (YYk - chi2_k)
+        return -explained / YY_C
+
+    grid = np.linspace(0, 1, nphase, endpoint=False)
+    vals = np.array([neg_power(p) for p in grid])
+    i = int(np.argmin(vals))
+    best = vals[i]
+    lo, hi = grid[(i - 1) % nphase], grid[(i + 1) % nphase]
+    if lo < hi:
+        res = minimize_scalar(neg_power, bounds=(lo, hi), method='bounded')
+        best = min(best, res.fun)
+    return -best
+
+
 def _scan_and_refine(chi2_amp_fn, nphase=2000):
     """Minimize chi2 over phase subject to amplitude >= 0.
 
@@ -238,6 +283,44 @@ def test_k2_sesar_matches_brute_force():
                             relative_offsets=lam)
         assert abs(p_ftp - p_bf) < 2e-3, \
             "D: f=%.4f ftp=%.5f brute=%.5f" % (f, p_ftp, p_bf)
+
+
+def test_k1_shared_phase_reduces_to_single_band():
+    # model B does not enforce positivity, so it matches the (unfiltered)
+    # single-band public power exactly at K=1.
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0,))
+    order = np.argsort(t)   # single-band path requires globally-sorted t
+    sb = FastTemplatePeriodogram(TEMPLATE).fit(t[order], y[order],
+                                               dy[order]).power(FREQS)
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='shared_phase')
+    mb.fit(t, y, bands, dy)
+    p = mb.power(FREQS)
+    assert np.allclose(p, sb, atol=1e-6), \
+        "K=1 shared_phase deviates from single-band by %.2e" % np.max(np.abs(p - sb))
+
+
+def test_k2_shared_phase_matches_brute_force():
+    offs = (0.0, -0.6, 0.4)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs)
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='shared_phase')
+    mb.fit(t, y, bands, dy)
+    for f in (0.123, 0.0917, 0.2013):
+        p_ftp = float(mb.power(f))
+        p_bf = _brute_power_shared_phase(t, y, bands, dy, TEMPLATE, f)
+        assert abs(p_ftp - p_bf) < 2e-3, \
+            "B: f=%.4f ftp=%.5f brute=%.5f" % (f, p_ftp, p_bf)
+
+
+def test_shared_phase_recovers_signal():
+    offs = (0.0, -0.8, 0.5)
+    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=offs)
+    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='shared_phase')
+    mb.fit(t, y, bands, dy)
+    f, p = mb.autopower(minimum_frequency=0.05, maximum_frequency=0.30)
+    assert abs(f[np.argmax(p)] - 0.123) < 1e-3
+    # all per-band amplitudes are positive for this genuine in-phase signal
+    for pars in mb.best_model.parameters.params_by_band.values():
+        assert pars.a > 0
 
 
 def test_k2_independent_matches_brute_force():
@@ -345,14 +428,6 @@ def test_sesar_without_offsets_raises():
     mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='sesar')
     mb.fit(t, y, bands, dy)
     with pytest.raises(ValueError):
-        mb.autopower()
-
-
-def test_shared_phase_raises_not_implemented():
-    t, y, bands, dy = _simulate(TEMPLATE, band_offsets=(0.0, 0.3))
-    mb = FastMultibandTemplatePeriodogram(TEMPLATE, mode='shared_phase')
-    mb.fit(t, y, bands, dy)
-    with pytest.raises(NotImplementedError):
         mb.autopower()
 
 


### PR DESCRIPTION
**Stacked on #36** (base: `v0.2-core-refactor`, which stacks on #35). This PR's diff is the multiband feature only; review #36 first. When #35/#36 merge, GitHub auto-retargets this to the new base.

Implements the multiband template periodogram (thesis appendix `chapter-appendices/multiband-template.tex`; Sesar et al. 2016; VanderPlas & Ivezić 2015).

## API
`FastMultibandTemplatePeriodogram(templates, mode='floating_offsets', relative_offsets=None)` — a drop-in sibling of `FastTemplatePeriodogram` over flat `(t, y, bands, dy)` data (the gatspy/astropy `LombScargleMultiband` convention; = a ZTF detection table). Distinct from `FastMultiTemplatePeriodogram` (multiple *templates*, one band).

## Sharing modes (what is held in common across bands)
| `mode` | shared | free per band | poly degree |
|---|---|---|---|
| `independent` (A) | nothing | amplitude, phase, offset | single-band, K solves |
| `shared_phase` (B) | phase | amplitude, offset | new, ~8HK |
| `floating_offsets` (C, **default**) | amplitude, phase | offset | single-band |
| `sesar` (D) | amplitude, phase, offset (fixed λ) | — | single-band |

- C/D reuse the factored `core` solver: build per-band `YM`/`MM`, combine, call the shared root tail. **C** is the plain `W_k`-weighted average; **D** adds global-mean corrections (`YM += ΣW_k(ȳ_k−ȳ_global)M̄_k`, `MM += ΣW_k M̄_k² − (ΣW_k M̄_k)²`).
- **A** combines bands as the global variance-explained fraction (comparable to C/D / multiband-LS).
- **B** needs a new degree-`8HK−1` stationarity polynomial (cost ~`(HK)³`/freq); shares the phase, so it does not force per-band positivity.
- A list of templates is a **catalog** (per-frequency max over sets; winning set on `best_model.template_set_index`); the template-independent per-band NFFT is computed once and reused across sets.

## Correctness
- **K=1 reduces exactly** to the single-band path (~1e-9).
- **K≥2 brute-force oracle** (independent phase scan + weighted least squares, same θ₁≥0 constraint) validates every mode to < 2e-3, including `test_C_and_D_are_not_conflated` (C beats a misspecified D — impossible if D silently computed C).
- Positivity (K.18) via the `roots_from_YM_MM` filter (not a half-phase flip, which only preserves the curve for H=1).
- Degenerate/flat data (YY=0, empty root set, non-finite F) returns finite zero power instead of NaN/crash.

**Full suite: 122 pass / 1 skip / 2 pre-existing fails.**

## Known follow-ups (not in this PR)
- The single-band *public* API does not yet enforce K.18, so it diverges from multiband-at-K=1 for negative-amplitude best fits. Landing K.18 in `core` (one shared policy) is the clean follow-up.
- `modeler.autofrequency` has the same `min`-vs-`max` `nf0` bug fixed here in `multiband.autofrequency` (silently-ignored `minimum_frequency`) — candidate for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)