### PR TITLE
Phase 3.2: controlled-simulation period-recovery harness + greedy seam

### DIFF
--- a/ftperiodogram/__init__.py
+++ b/ftperiodogram/__init__.py
@@ -6,3 +6,11 @@ from .multiband import (FastMultibandTemplatePeriodogram,
 from .template import Template
 from .catalog_builder import (build_template_catalog, templates_from_sampled,
                               fetch_sesar_templates, CatalogDiagnostics)
+from .simulate import (Cadence, SyntheticCadence, CadenceSample, exp_mag_error,
+                       simulate_lightcurve, simulate_multiband_lightcurve,
+                       SimulatedLightCurve, SimulatedMultibandLightCurve)
+from .recovery import (recovered_fractional, recovered_phase_coherence,
+                       harmonic_alias_set, classify_recovery, recovery_rate,
+                       RecoveryResult, AliasMatch)
+from .validation import (RecoveryScorer, make_recovery_scorer, k_sweep_recovery,
+                         KSweepResult, frequency_grid)

--- a/ftperiodogram/catalog_builder.py
+++ b/ftperiodogram/catalog_builder.py
@@ -389,11 +389,90 @@ def _orbit_chart_agreement(templates, medoid_idx, a1_floor, harmonic_weights):
     return float(np.mean(orbit_assign[valid] == chart_assign[valid]))
 
 
+def _fill_by_diversity(chosen_work, remaining_work, D, k_needed):
+    """Pad a greedy selection by ``k_needed`` templates chosen for orbit-diversity.
+
+    Used when simulated recovery saturates before ``n_clusters`` templates are
+    picked: add the remaining templates farthest (in the distance matrix ``D``)
+    from the already-chosen set, so the returned vocabulary still has size K.
+    """
+    chosen_work = list(chosen_work)
+    remaining_work = list(remaining_work)
+    out = []
+    for _ in range(int(k_needed)):
+        if not remaining_work:
+            break
+        if chosen_work and D is not None:
+            dmin = [min(D[r, c] for c in chosen_work) for r in remaining_work]
+            pick = remaining_work[int(np.argmax(dmin))]
+        else:
+            pick = remaining_work[0]
+        out.append(int(pick))
+        chosen_work.append(int(pick))
+        remaining_work.remove(pick)
+    return out
+
+
+def _greedy_select(work, n_clusters, scorer, *, D=None, candidate_pool=None,
+                   random_state=None):
+    """Recovery-driven greedy forward selection (the ``method='greedy'`` path).
+
+    At each step add, from the candidate universe, the template that recovers the
+    most *not-yet-recovered* sources -- the greedy set-cover step on the
+    per-template standalone recovered masks (``scorer.source_masks``).  This union
+    is the selection *signal*; the returned ``cost = 1 - scorer(vocabulary)`` is the
+    *actual* catalog recovery (honest even where catalog-mode's per-frequency max
+    moves the global peak so the union over-counts).  The return contract matches
+    :func:`_pam`: ``(medoid_indices, labels, cost)`` with ``labels`` the
+    orbit-nearest assignment of every template to a chosen medoid.
+
+    When recovery saturates before ``n_clusters`` are chosen, the selection is
+    padded to size K by orbit-diversity (the saturation point is itself a result --
+    the knee of the recovery-vs-K curve).
+    """
+    n = len(work)
+    if candidate_pool in (None, 'all'):
+        universe = np.arange(n)
+    else:
+        raise ValueError("unknown candidate_pool %r; expected None or 'all' "
+                         "(PAM pre-filtering is a deferred extension)"
+                         % (candidate_pool,))
+
+    cand_masks = np.asarray(
+        scorer.source_masks([work[int(i)] for i in universe]), dtype=bool)
+    covered = np.zeros(int(scorer.n_sources), dtype=bool)
+    chosen = []                              # work-indices, in selection order
+    remaining = list(range(len(universe)))   # local indices into ``universe``
+
+    while len(chosen) < n_clusters and remaining and not covered.all():
+        rem = np.array(remaining)
+        gains = cand_masks[rem][:, ~covered].sum(axis=1)
+        if gains.max() == 0:
+            break                            # nothing left improves recovery
+        # most new recoveries; ties broken by lowest universe index (deterministic)
+        best = int(np.lexsort((universe[rem], -gains))[0])
+        pick_local = int(rem[best])
+        chosen.append(int(universe[pick_local]))
+        covered |= cand_masks[pick_local]
+        remaining.remove(pick_local)
+
+    if len(chosen) < n_clusters and remaining:
+        chosen += _fill_by_diversity(
+            chosen, [int(universe[j]) for j in remaining], D,
+            n_clusters - len(chosen))
+
+    medoid_idx = np.array(sorted(dict.fromkeys(chosen)), dtype=int)
+    labels = (np.argmin(D[:, medoid_idx], axis=1).astype(int)
+              if D is not None else np.zeros(n, dtype=int))
+    cost = 1.0 - float(scorer([work[int(i)] for i in medoid_idx]))
+    return medoid_idx, labels, cost
+
+
 def build_template_catalog(templates, n_clusters, metric='orbit',
                            n_harmonics=None, harmonic_weights=None,
                            a1_floor=1e-8, n_init=10, max_iter=300,
-                           random_state=None, method='pam',
-                           return_diagnostics=False):
+                           random_state=None, method='pam', scorer=None,
+                           candidate_pool=None, return_diagnostics=False):
     """Compress ``templates`` into ``n_clusters`` representative templates.
 
     Clusters the input templates with k-medoids/PAM under the orbit-minimized
@@ -418,9 +497,18 @@ def build_template_catalog(templates, n_clusters, metric='orbit',
         Optional per-harmonic weights for the chart metric (length ``H-1``).
     n_init, max_iter, random_state :
         PAM multi-start, swap-iteration cap, and seeding.
-    method : {'pam'}
-        Selection method.  ``'greedy'`` (recovery-driven) is reserved and
-        raises ``NotImplementedError`` until the Phase-3 simulation harness lands.
+    method : {'pam', 'greedy'}
+        Selection method.  ``'pam'`` (default) clusters under the distance matrix.
+        ``'greedy'`` is recovery-driven forward selection and requires ``scorer``.
+    scorer : callable or None
+        Period-recovery scorer for ``method='greedy'`` (e.g. from
+        :func:`ftperiodogram.validation.make_recovery_scorer`); must expose
+        ``n_sources`` and ``source_masks(templates) -> (len(templates), n_sources)``
+        bool array, and be callable ``scorer(templates) -> recovery_rate``.
+        Ignored for ``method='pam'``.
+    candidate_pool : {None, 'all'}
+        Candidate universe for greedy selection; ``None``/``'all'`` use every input
+        template (PAM pre-filtering is a deferred extension).
     return_diagnostics : bool
         If ``True``, also return a :class:`CatalogDiagnostics`.
 
@@ -434,13 +522,9 @@ def build_template_catalog(templates, n_clusters, metric='orbit',
     templates = list(templates)
     n = len(templates)
 
-    if method != 'pam':
-        if method == 'greedy':
-            raise NotImplementedError(
-                "recovery-driven greedy selection (method='greedy') requires the "
-                "Phase-3 simulation harness and is not implemented yet; "
-                "use method='pam'")
-        raise ValueError("unknown method %r; expected 'pam'" % (method,))
+    if method not in ('pam', 'greedy'):
+        raise ValueError("unknown method %r; expected 'pam' or 'greedy'"
+                         % (method,))
     if metric not in ('orbit', 'chart'):
         raise ValueError("metric must be 'orbit' or 'chart'; got %r" % (metric,))
     if not 1 <= n_clusters <= n:
@@ -459,8 +543,20 @@ def build_template_catalog(templates, n_clusters, metric='orbit',
                 "chart metric is singular (A_1 -> 0) for at least one template; "
                 "use metric='orbit', which has no such singularity")
 
-    medoid_idx, labels, cost = _pam(D, n_clusters, n_init=n_init,
-                                    max_iter=max_iter, random_state=random_state)
+    if method == 'greedy':
+        if scorer is None:
+            raise NotImplementedError(
+                "recovery-driven greedy selection (method='greedy') requires a "
+                "period-recovery scorer; pass "
+                "scorer=ftperiodogram.validation.make_recovery_scorer(...). "
+                "PAM remains the default.")
+        medoid_idx, labels, cost = _greedy_select(
+            work, n_clusters, scorer, D=D, candidate_pool=candidate_pool,
+            random_state=random_state)
+    else:
+        medoid_idx, labels, cost = _pam(D, n_clusters, n_init=n_init,
+                                        max_iter=max_iter,
+                                        random_state=random_state)
     vocabulary = [work[idx] for idx in medoid_idx]
 
     if not return_diagnostics:

--- a/ftperiodogram/recovery.py
+++ b/ftperiodogram/recovery.py
@@ -1,0 +1,192 @@
+"""Period-recovery metrics for the controlled-simulation harness (Phase 3.2).
+
+Two recovery conventions, reported BOTH (design memo ``phase3_vocab_design.md`` S2):
+
+  (a) hard fractional threshold      ``|P_rec - P_true| / P_true < rtol``  (rtol=0.01;
+      DES/ZTF RRL convention, Stringer et al. 2019 "89% within 1%");
+  (b) baseline-aware phase coherence ``|df| * T < delta_phi_max``          (Graham et al.
+      2013) with ``df = |1/P_rec - 1/P_true|`` and ``T`` the observing baseline.
+
+Each is scored EXACT (against ``P_true``) and EXACT-OR-HARMONIC (also against a
+configurable set of period aliases -- ``P/2, 2P, P/3, 3P`` and the 1-day / 1-year
+window beats, VanderPlas 2018), with the matching alias *named* for diagnostics.
+
+The fractional criterion is the headline that drives the recovery-vs-K curve and
+the greedy selector's objective; phase coherence is the strict secondary curve
+(``delta_phi_max=0.5`` = a half-cycle of accumulated drift over the baseline, i.e.
+the Rayleigh spectral-window main-lobe half-width).
+
+Pure numpy -- no FTP coupling -- so the metrics are unit-testable in isolation.
+"""
+from collections import namedtuple
+
+import numpy as np
+
+
+# ----------------------------------------------------------------------
+# The two recovery conventions (each a pure boolean test)
+# ----------------------------------------------------------------------
+def recovered_fractional(P_rec, P_true, rtol=0.01):
+    """Hard fractional threshold: ``|P_rec - P_true| / P_true < rtol``.
+
+    Non-positive ``P_rec`` is never recovered.  Accepts scalar or ``array_like``
+    ``P_rec`` and returns a matching Python ``bool`` (scalar input) or numpy
+    ``bool`` array.
+    """
+    P_rec = np.asarray(P_rec, dtype=float)
+    P_true = np.asarray(P_true, dtype=float)
+    ok = (np.abs(P_rec - P_true) < rtol * np.abs(P_true)) & (P_rec > 0)
+    return ok if ok.ndim else bool(ok)
+
+
+def recovered_phase_coherence(P_rec, P_true, baseline, delta_phi_max=0.5):
+    """Baseline-aware phase coherence: ``|df| * T < delta_phi_max``.
+
+    ``df = |1/P_rec - 1/P_true|`` is the frequency error and ``T = baseline`` the
+    observing time span (``t.max() - t.min()``).  The product is the total phase
+    drift, in cycles, accumulated across the baseline.  Non-positive ``P_rec`` is
+    never recovered.  Scalar/array semantics match :func:`recovered_fractional`.
+    """
+    P_rec = np.asarray(P_rec, dtype=float)
+    P_true = np.asarray(P_true, dtype=float)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        delta_f = np.abs(1.0 / P_rec - 1.0 / P_true)
+    ok = (delta_f * baseline < delta_phi_max) & (P_rec > 0)
+    return ok if ok.ndim else bool(ok)
+
+
+# ----------------------------------------------------------------------
+# Configurable harmonic / window-beat alias set
+# ----------------------------------------------------------------------
+#: One candidate alias period whose recovery counts as exact-or-harmonic success.
+AliasMatch = namedtuple('AliasMatch', ['name', 'P_alias', 'multiplier'])
+
+
+def harmonic_alias_set(P_true, baseline=None, harmonics=(0.5, 2.0, 1.0 / 3.0, 3.0),
+                       day_beats=(1, 2), year_beats=(1,), day=1.0, year=365.25):
+    """Configurable period-alias candidate set for ``P_true``.
+
+    Returns a list of :class:`AliasMatch`:
+
+      * harmonic multiples ``P_true * m`` for ``m`` in ``harmonics`` -> P/2, 2P, P/3, 3P;
+      * 1-day window beats ``1 / (f_true +/- n/day)``  for ``n`` in ``day_beats``;
+      * 1-year window beats ``1 / (f_true +/- n/year)`` for ``n`` in ``year_beats``;
+
+    where ``f_true = 1/P_true``.  Beats yielding a non-positive frequency are
+    dropped.  ``baseline`` is accepted (and ignored) so the signature matches the
+    other helpers; aliases do not depend on it.
+    """
+    P_true = float(P_true)
+    f_true = 1.0 / P_true
+    aliases = []
+    for m in harmonics:
+        m = float(m)
+        if m <= 0:
+            continue
+        if m >= 1:
+            name = ("%dP" % int(round(m)) if abs(m - round(m)) < 1e-9
+                    else "%gP" % m)
+        else:
+            name = "P/%d" % int(round(1.0 / m))
+        aliases.append(AliasMatch(name=name, P_alias=P_true * m, multiplier=m))
+    for unit_name, unit, beats in (("day", day, day_beats),
+                                   ("year", year, year_beats)):
+        for n in beats:
+            for sign in (+1, -1):
+                f = f_true + sign * n / unit
+                if f <= 0:
+                    continue
+                name = "beat_%s%d/%s" % ("+" if sign > 0 else "-", n, unit_name)
+                aliases.append(AliasMatch(name=name, P_alias=1.0 / f,
+                                          multiplier=float('nan')))
+    return aliases
+
+
+# ----------------------------------------------------------------------
+# Unified per-source classifier and population aggregator
+# ----------------------------------------------------------------------
+#: Per-source recovery verdict under one convention, with exact vs
+#: exact-or-harmonic broken out and the matching alias named.
+RecoveryResult = namedtuple(
+    'RecoveryResult',
+    ['recovered', 'exact', 'exact_or_harmonic', 'criterion', 'alias_name',
+     'P_rec', 'P_true', 'delta_f', 'baseline'])
+
+
+def classify_recovery(P_rec, P_true, baseline=None, criterion='fractional',
+                      rtol=0.01, delta_phi_max=0.5, count_harmonics=True,
+                      aliases=None, **alias_kwargs):
+    """Score a single recovered period ``P_rec`` against truth ``P_true``.
+
+    ``criterion`` selects the convention: ``'fractional'`` (default, the headline)
+    or ``'phase_coherence'`` (requires ``baseline``).  ``exact`` tests against
+    ``P_true``; ``exact_or_harmonic`` additionally tests the alias set (built from
+    :func:`harmonic_alias_set` unless ``aliases`` is passed), recording the first
+    matching alias in ``alias_name``.  ``recovered`` follows ``exact_or_harmonic``
+    when ``count_harmonics`` (default), else ``exact``.  Extra keyword arguments
+    are forwarded to :func:`harmonic_alias_set`.
+    """
+    P_rec = float(P_rec)
+    P_true = float(P_true)
+
+    if criterion == 'fractional':
+        def _test(target):
+            return bool(recovered_fractional(P_rec, target, rtol=rtol))
+    elif criterion == 'phase_coherence':
+        if baseline is None:
+            raise ValueError("criterion='phase_coherence' requires `baseline` "
+                             "(the observing time span T)")
+
+        def _test(target):
+            return bool(recovered_phase_coherence(P_rec, target, baseline,
+                                                  delta_phi_max=delta_phi_max))
+    else:
+        raise ValueError("unknown criterion %r; expected 'fractional' or "
+                         "'phase_coherence'" % (criterion,))
+
+    exact = _test(P_true)
+
+    alias_name = None
+    if not exact:
+        if aliases is None:
+            aliases = harmonic_alias_set(P_true, baseline=baseline, **alias_kwargs)
+        for alias in aliases:
+            if _test(alias.P_alias):
+                alias_name = alias.name
+                break
+
+    exact_or_harmonic = exact or (alias_name is not None)
+    recovered = exact_or_harmonic if count_harmonics else exact
+
+    delta_f = abs(1.0 / P_rec - 1.0 / P_true) if P_rec > 0 else float('inf')
+
+    return RecoveryResult(
+        recovered=recovered, exact=exact, exact_or_harmonic=exact_or_harmonic,
+        criterion=criterion, alias_name=alias_name, P_rec=P_rec, P_true=P_true,
+        delta_f=delta_f, baseline=baseline)
+
+
+def recovery_rate(results):
+    """Aggregate a sequence of :class:`RecoveryResult` into summary statistics.
+
+    Returns a ``dict`` with the headline ``recovered`` rate, the ``exact`` and
+    ``exact_or_harmonic`` fractions, the count ``n``, and an ``alias_breakdown``
+    counting which aliases accounted for the non-exact recoveries.  This scalar
+    summary is what the K-sweep driver and the greedy selector maximize.
+    """
+    results = list(results)
+    n = len(results)
+    if n == 0:
+        return {'recovered': 0.0, 'exact': 0.0, 'exact_or_harmonic': 0.0,
+                'n': 0, 'alias_breakdown': {}}
+    breakdown = {}
+    for r in results:
+        if r.alias_name is not None:
+            breakdown[r.alias_name] = breakdown.get(r.alias_name, 0) + 1
+    return {
+        'recovered': sum(1 for r in results if r.recovered) / n,
+        'exact': sum(1 for r in results if r.exact) / n,
+        'exact_or_harmonic': sum(1 for r in results if r.exact_or_harmonic) / n,
+        'n': n,
+        'alias_breakdown': breakdown,
+    }

--- a/ftperiodogram/simulate.py
+++ b/ftperiodogram/simulate.py
@@ -1,0 +1,275 @@
+"""Light-curve simulator and observing-cadence model (Phase 3.2 harness).
+
+Given a :class:`~ftperiodogram.template.Template`, an injected period, an observing
+:class:`Cadence`, and a photometric noise model, produce single-band ``(t, y, dy)``
+and multiband ``(t, y, bands, dy)`` light curves whose underlying signal matches the
+model :class:`~ftperiodogram.modeler.TemplateModel` fits::
+
+    y(t) = mean_mag + amplitude * template(t / period - tau) + noise
+
+The :class:`Cadence` abstraction is a one-method protocol (``sample(rng) ->
+CadenceSample``) so a *real* ZTF DR22 cadence drops in later as a subclass with
+zero churn to the simulators or the recovery metrics.  The bundled
+:class:`SyntheticCadence` produces random epochs inside a multi-year baseline with
+yearly seasonal gaps, per-band epoch counts, and a heteroscedastic
+error-vs-magnitude relation (fainter => larger sigma).
+
+stdlib + numpy only.  Observing windows are set by explicit time spans, never via a
+Nyquist heuristic.
+"""
+from collections import namedtuple
+
+import numpy as np
+
+
+def _as_rng(random_state):
+    """Coerce ``None`` / int / RandomState into a ``np.random.RandomState``."""
+    if isinstance(random_state, np.random.RandomState):
+        return random_state
+    return np.random.RandomState(random_state)
+
+
+# ----------------------------------------------------------------------
+# Error-vs-magnitude noise model
+# ----------------------------------------------------------------------
+def exp_mag_error(sigma_floor=0.01, sigma_scale=0.005, mag_ref=20.0,
+                  mag_scale=1.0, sigma_max=0.5):
+    """Heteroscedastic photometric error vs magnitude (fainter => larger sigma).
+
+    Returns a callable ``mag -> sigma`` so a measured ZTF ``sigma(mag)`` table can
+    later replace it with no API change::
+
+        sigma(mag) = clip(sigma_floor + sigma_scale * exp((mag - mag_ref)/mag_scale),
+                          sigma_floor, sigma_max)
+
+    Defaults give ~0.01 mag at the bright end rising toward the survey limit, with
+    a clip so the weights ``dy**-2`` never blow up.
+    """
+    def _sigma(mag):
+        mag = np.asarray(mag, dtype=float)
+        s = sigma_floor + sigma_scale * np.exp((mag - mag_ref) / mag_scale)
+        return np.clip(s, sigma_floor, sigma_max)
+    return _sigma
+
+
+# ----------------------------------------------------------------------
+# Cadence abstraction
+# ----------------------------------------------------------------------
+#: Result of sampling a cadence: observation epochs, per-epoch band labels
+#: (``None`` for single-band), and the error-vs-mag relation to apply.
+CadenceSample = namedtuple('CadenceSample', ['t', 'bands', 'mag_err_model'])
+
+
+def _in_season(t, t0, season_length_days, season_period_days):
+    """Boolean mask: epoch falls inside a visible (yearly) observing season."""
+    phase = np.mod(np.asarray(t, dtype=float) - t0, season_period_days)
+    return phase < season_length_days
+
+
+class Cadence(object):
+    """Abstract observing cadence.
+
+    Subclass and implement :meth:`sample` to map a request to observation epochs
+    plus an error-vs-magnitude relation.  A real ZTF DR22 cadence is a drop-in
+    subclass that returns its recorded epochs through the same
+    :class:`CadenceSample`.
+    """
+
+    def sample(self, rng=None):
+        """Return a :class:`CadenceSample`.  Implementations MUST return globally
+        ascending-sorted ``t``.  ``rng`` may be ``None`` / int / RandomState."""
+        raise NotImplementedError
+
+    @property
+    def baseline(self):
+        """A-priori observing time span ``T`` (days), if known before sampling."""
+        raise NotImplementedError
+
+
+class SyntheticCadence(Cadence):
+    """Random epochs in a multi-year baseline with yearly seasonal gaps.
+
+    Parameters
+    ----------
+    n_epochs : int or dict {band: int}, default 60
+        Per-band epoch counts.  An int means the same count in every band.
+    bands : sequence of hashable or None, default None
+        Band labels.  ``None`` => single-band (``CadenceSample.bands`` is ``None``).
+    baseline_days : float, default 3 * 365.25
+        Total observing window ``T``; epochs are drawn in ``[t0, t0 + baseline_days]``.
+    t0 : float, default 0.0
+        Window start (days).
+    season_length_days : float, default 270.0
+        Visible length of each yearly observing season (the rest is a gap).
+    season_period_days : float, default 365.25
+        Spacing between season starts (one season per year).
+    err_model : callable mag -> sigma or None
+        Error-vs-magnitude relation; defaults to :func:`exp_mag_error`.
+    random_state : int or RandomState or None
+        Default seed used by :meth:`sample` when no ``rng`` is passed.
+    max_draw_factor : int, default 20
+        Cap on rejection-sampling batches before giving up (degenerate duty cycle).
+    """
+
+    def __init__(self, n_epochs=60, bands=None, baseline_days=3 * 365.25, t0=0.0,
+                 season_length_days=270.0, season_period_days=365.25,
+                 err_model=None, random_state=None, max_draw_factor=20):
+        if baseline_days <= 0:
+            raise ValueError("baseline_days must be positive")
+        if not 0 < season_length_days <= season_period_days:
+            raise ValueError("require 0 < season_length_days <= season_period_days")
+        if bands is None and isinstance(n_epochs, dict):
+            raise ValueError("dict n_epochs requires explicit `bands`")
+        self.n_epochs = n_epochs
+        self.bands = None if bands is None else list(bands)
+        self.baseline_days = float(baseline_days)
+        self.t0 = float(t0)
+        self.season_length_days = float(season_length_days)
+        self.season_period_days = float(season_period_days)
+        self.err_model = exp_mag_error() if err_model is None else err_model
+        self.random_state = random_state
+        self.max_draw_factor = int(max_draw_factor)
+
+    @property
+    def baseline(self):
+        return self.baseline_days
+
+    def _draw_epochs(self, count, rng):
+        """Rejection-sample ``count`` in-season epochs; sorted ascending."""
+        if count <= 0:
+            raise ValueError("per-band epoch count must be positive; got %r"
+                             % (count,))
+        kept, n_kept, attempts = [], 0, 0
+        batch = max(count * 4, 16)
+        while n_kept < count and attempts < self.max_draw_factor:
+            cand = self.t0 + rng.rand(batch) * self.baseline_days
+            cand = cand[_in_season(cand, self.t0, self.season_length_days,
+                                   self.season_period_days)]
+            kept.append(cand)
+            n_kept += len(cand)
+            attempts += 1
+        t = np.concatenate(kept) if kept else np.array([])
+        if len(t) < count:
+            raise ValueError("could not draw %d in-season epochs in %d batches "
+                             "(duty cycle too low?)" % (count, self.max_draw_factor))
+        return np.sort(t[:count])
+
+    def sample(self, rng=None):
+        rng = _as_rng(self.random_state if rng is None else rng)
+        if self.bands is None:
+            if isinstance(self.n_epochs, dict):
+                raise ValueError("dict n_epochs requires explicit `bands`")
+            t = self._draw_epochs(int(self.n_epochs), rng)
+            return CadenceSample(t=t, bands=None, mag_err_model=self.err_model)
+
+        if isinstance(self.n_epochs, dict):
+            counts = {b: int(self.n_epochs[b]) for b in self.bands}
+        else:
+            counts = {b: int(self.n_epochs) for b in self.bands}
+        t_parts, b_parts = [], []
+        for b in self.bands:
+            tb = self._draw_epochs(counts[b], rng)
+            t_parts.append(tb)
+            b_parts.append(np.full(counts[b], b))
+        t = np.concatenate(t_parts)
+        bands = np.concatenate(b_parts)
+        order = np.argsort(t, kind='mergesort')
+        return CadenceSample(t=t[order], bands=bands[order],
+                             mag_err_model=self.err_model)
+
+
+# ----------------------------------------------------------------------
+# Simulators
+# ----------------------------------------------------------------------
+SimulatedLightCurve = namedtuple(
+    'SimulatedLightCurve',
+    ['t', 'y', 'dy', 'period', 'frequency', 'params', 'cadence'])
+
+SimulatedMultibandLightCurve = namedtuple(
+    'SimulatedMultibandLightCurve',
+    ['t', 'y', 'bands', 'dy', 'period', 'frequency', 'params', 'cadence'])
+
+
+def simulate_lightcurve(template, period, cadence, amplitude=0.5, mean_mag=15.0,
+                        tau=0.0, random_state=None, add_noise=True):
+    """Single-band light curve from a ``template`` on a (single-band) ``cadence``.
+
+    ``y = mean_mag + amplitude * template(t/period - tau)``; per-epoch ``dy`` comes
+    from the cadence's error-vs-mag model evaluated at the clean magnitude, and
+    Gaussian noise of that scale is added when ``add_noise``.  ``t`` is returned
+    ascending-sorted (the single-band modeler contract).  ``tau`` is a phase offset
+    in turns.
+    """
+    period = float(period)
+    if period <= 0:
+        raise ValueError("period must be positive")
+    rng = _as_rng(random_state)
+    sample = cadence.sample(rng)
+    if sample.bands is not None:
+        raise ValueError("simulate_lightcurve needs a single-band cadence; use "
+                         "simulate_multiband_lightcurve for a multiband cadence")
+    t = np.sort(np.asarray(sample.t, dtype=float))
+    if t.size < 2:
+        raise ValueError("need at least 2 epochs to simulate a light curve")
+    y_clean = mean_mag + amplitude * np.asarray(template(t / period - tau))
+    dy = np.maximum(np.asarray(sample.mag_err_model(y_clean), dtype=float), 1e-12)
+    y = y_clean + dy * rng.randn(t.size) if add_noise else y_clean
+    params = dict(amplitude=amplitude, mean_mag=mean_mag, tau=tau,
+                  add_noise=add_noise)
+    return SimulatedLightCurve(t=t, y=y, dy=dy, period=period,
+                               frequency=1.0 / period, params=params,
+                               cadence=cadence)
+
+
+def simulate_multiband_lightcurve(template, period, cadence, amplitude=0.5,
+                                  mean_mag=15.0, tau=0.0, band_amplitudes=None,
+                                  band_offsets=None, random_state=None,
+                                  add_noise=True, shuffle=True):
+    """Multiband light curve sharing one shape across bands (floating-offsets regime).
+
+    For band ``b``::
+
+        y_b = mean_mag + band_offsets[b]
+              + amplitude * band_amplitudes[b] * template(t/period - tau)
+
+    ``band_amplitudes`` / ``band_offsets`` are dicts keyed by the cadence's band
+    labels (``None`` => 1.0 / 0.0 everywhere, i.e. a pure shared shape that exactly
+    matches the modeler's ``floating_offsets`` mode).  With ``shuffle`` the flat
+    arrays are returned in random global order (the multiband modeler needs no
+    sorting).
+    """
+    period = float(period)
+    if period <= 0:
+        raise ValueError("period must be positive")
+    rng = _as_rng(random_state)
+    sample = cadence.sample(rng)
+    if sample.bands is None:
+        raise ValueError("simulate_multiband_lightcurve needs a multiband cadence")
+    t = np.asarray(sample.t, dtype=float)
+    bands = np.asarray(sample.bands)
+    uniq = list(dict.fromkeys(bands.tolist()))
+    if band_amplitudes is not None:
+        missing = [b for b in uniq if b not in band_amplitudes]
+        if missing:
+            raise ValueError("band_amplitudes missing bands %r" % (missing,))
+    if band_offsets is not None:
+        missing = [b for b in uniq if b not in band_offsets]
+        if missing:
+            raise ValueError("band_offsets missing bands %r" % (missing,))
+    amp_vec = np.array([1.0 if band_amplitudes is None else band_amplitudes[b]
+                        for b in bands.tolist()], dtype=float)
+    off_vec = np.array([0.0 if band_offsets is None else band_offsets[b]
+                        for b in bands.tolist()], dtype=float)
+    shape = np.asarray(template(t / period - tau))
+    y_clean = mean_mag + off_vec + amplitude * amp_vec * shape
+    dy = np.maximum(np.asarray(sample.mag_err_model(y_clean), dtype=float), 1e-12)
+    y = y_clean + dy * rng.randn(t.size) if add_noise else y_clean
+    if shuffle:
+        order = rng.permutation(t.size)
+        t, y, bands, dy = t[order], y[order], bands[order], dy[order]
+    params = dict(amplitude=amplitude, mean_mag=mean_mag, tau=tau,
+                  band_amplitudes=band_amplitudes, band_offsets=band_offsets,
+                  add_noise=add_noise)
+    return SimulatedMultibandLightCurve(t=t, y=y, bands=bands, dy=dy,
+                                        period=period, frequency=1.0 / period,
+                                        params=params, cadence=cadence)

--- a/ftperiodogram/tests/test_catalog_builder.py
+++ b/ftperiodogram/tests/test_catalog_builder.py
@@ -416,3 +416,100 @@ def test_public_api_exports():
     for name in ('build_template_catalog', 'templates_from_sampled',
                  'fetch_sesar_templates', 'CatalogDiagnostics'):
         assert hasattr(ftperiodogram, name)
+
+
+# ----------------------------------------------------------------------
+# Recovery-driven greedy selection (method='greedy')
+# ----------------------------------------------------------------------
+class _FakeRecoveryScorer:
+    """Deterministic stand-in for ftperiodogram.validation.RecoveryScorer.
+
+    Each source 'wants' one of the three archetypes; a template recovers that
+    source iff it is orbit-closest to the wanted archetype, and catalog recovery
+    is the union over the set.  This exercises greedy's not-yet-recovered
+    targeting and the (medoid, labels, cost) contract without running any FTP."""
+
+    def __init__(self, n_sources=12):
+        self.n_sources = n_sources
+        self.criterion = 'fractional'
+        self._arch = [Template(c, s) for c, s in _ARCHETYPES]
+        self._want = np.arange(n_sources) % len(self._arch)
+
+    def _which_arch(self, tmpl):
+        return int(np.argmin([cb._orbit_distance(tmpl, a) for a in self._arch]))
+
+    def source_masks(self, templates):
+        cols = [self._which_arch(t) for t in templates]
+        return np.array([[self._want[i] == c for i in range(self.n_sources)]
+                         for c in cols], dtype=bool)
+
+    def __call__(self, templates, *, return_mask=False):
+        templates = list(templates)
+        if not templates:
+            mask = np.zeros(self.n_sources, dtype=bool)
+        else:
+            mask = self.source_masks(templates).any(axis=0)   # catalog == union
+        rate = float(mask.mean())
+        return (rate, mask) if return_mask else rate
+
+
+def test_greedy_requires_scorer():
+    templates, _ = _archetype_population(seed=1)
+    with pytest.raises(NotImplementedError):
+        cb.build_template_catalog(templates, 3, method='greedy')
+
+
+def test_greedy_targets_not_yet_recovered():
+    templates, _ = _archetype_population(seed=1)
+    scorer = _FakeRecoveryScorer(n_sources=12)
+    vocab, diag = cb.build_template_catalog(
+        templates, 3, method='greedy', scorer=scorer, return_diagnostics=True)
+    assert len(vocab) == 3
+    # greedy must spread across the three archetypes -> full recovery (cost 0);
+    # a naive 'highest total recovery' rule would pile onto one archetype
+    assert {scorer._which_arch(t) for t in vocab} == {0, 1, 2}
+    assert diag.total_cost == pytest.approx(0.0)
+
+
+def test_greedy_returns_pam_compatible_diagnostics():
+    templates, _ = _archetype_population(seed=2)
+    scorer = _FakeRecoveryScorer(n_sources=12)
+    vocab, diag = cb.build_template_catalog(
+        templates, 3, method='greedy', scorer=scorer, return_diagnostics=True)
+    for t in vocab:
+        npt.assert_allclose(np.sum(t.c_n ** 2 + t.s_n ** 2), 1.0, atol=1e-9)
+    assert diag.medoid_indices.shape == (3,)
+    assert diag.labels.shape == (len(templates),)
+    assert set(diag.labels.tolist()) <= set(range(3))
+    assert int(diag.cluster_sizes.sum()) == len(templates)
+    assert diag.orbit_chart_agreement is not None
+    assert 0.0 <= diag.total_cost <= 1.0
+
+
+def test_greedy_is_deterministic():
+    templates, _ = _archetype_population(seed=3)
+    scorer = _FakeRecoveryScorer(n_sources=12)
+    v1, d1 = cb.build_template_catalog(templates, 3, method='greedy',
+                                       scorer=scorer, return_diagnostics=True)
+    v2, d2 = cb.build_template_catalog(templates, 3, method='greedy',
+                                       scorer=scorer, return_diagnostics=True)
+    npt.assert_array_equal(d1.medoid_indices, d2.medoid_indices)
+    npt.assert_array_equal(d1.labels, d2.labels)
+
+
+def test_greedy_fills_to_k_when_recovery_saturates():
+    templates, _ = _archetype_population(seed=1)
+    scorer = _FakeRecoveryScorer(n_sources=12)
+    # 3 templates already saturate recovery; asking for 5 must still return 5
+    vocab, diag = cb.build_template_catalog(
+        templates, 5, method='greedy', scorer=scorer, return_diagnostics=True)
+    assert len(vocab) == 5
+    assert diag.total_cost == pytest.approx(0.0)   # extra templates add no recovery
+
+
+def test_greedy_rejects_unknown_candidate_pool():
+    templates, _ = _archetype_population(seed=1)
+    scorer = _FakeRecoveryScorer()
+    with pytest.raises(ValueError):
+        cb.build_template_catalog(templates, 2, method='greedy', scorer=scorer,
+                                  candidate_pool='pam:4')

--- a/ftperiodogram/tests/test_harness_integration.py
+++ b/ftperiodogram/tests/test_harness_integration.py
@@ -1,0 +1,60 @@
+"""Keystone integration tests: simulate -> FTP -> recovery (Phase 3.2 harness).
+
+These tie the three new harness layers together against the real modeler.  The
+search grid is an explicit ``[f_min, f_max]`` (no nyquist_factor) with a documented
+spacing ``df = 1/(T * samples_per_peak)`` fine enough that grid resolution is not
+the limiting factor -- the noise-free test asserts recovery *to grid resolution*.
+"""
+import numpy as np
+import numpy.testing as npt
+
+from ftperiodogram.template import Template
+from ftperiodogram import simulate as sim
+from ftperiodogram import FastTemplatePeriodogram
+from ftperiodogram.recovery import classify_recovery
+
+
+def _rrl_like_template():
+    # a non-sinusoidal, multi-harmonic shape (the regime where templates help)
+    return Template([1.0, 0.4, 0.2], [0.0, 0.1, 0.05])
+
+
+def test_noise_free_recovers_injected_period_to_grid_resolution():
+    tmpl = _rrl_like_template()
+    P_true = 0.6
+    cad = sim.SyntheticCadence(n_epochs=60, baseline_days=365.25,
+                               random_state=11)
+    lc = sim.simulate_lightcurve(tmpl, P_true, cad, amplitude=0.8, mean_mag=15.0,
+                                 random_state=11, add_noise=False)
+    T = lc.t.max() - lc.t.min()
+
+    spp = 8
+    model = FastTemplatePeriodogram(template=tmpl).fit(lc.t, lc.y, lc.dy)
+    freqs, power = model.autopower(minimum_frequency=0.5, maximum_frequency=2.5,
+                                   samples_per_peak=spp, fast=True)
+    df = freqs[1] - freqs[0]
+    npt.assert_allclose(df, 1.0 / (T * spp), rtol=1e-6)   # documented grid spacing
+
+    f_peak = freqs[int(np.argmax(power))]
+    assert abs(f_peak - 1.0 / P_true) <= df               # recovered to grid resolution
+
+    r = classify_recovery(1.0 / f_peak, P_true, baseline=T, criterion='fractional')
+    assert r.exact is True
+
+
+def test_simulate_then_classify_high_snr_noisy():
+    tmpl = _rrl_like_template()
+    P_true = 0.55
+    cad = sim.SyntheticCadence(n_epochs=80, baseline_days=365.25,
+                               random_state=21)
+    lc = sim.simulate_lightcurve(tmpl, P_true, cad, amplitude=1.0, mean_mag=14.0,
+                                 random_state=22, add_noise=True)
+    T = lc.t.max() - lc.t.min()
+
+    model = FastTemplatePeriodogram(template=tmpl).fit(lc.t, lc.y, lc.dy)
+    freqs, power = model.autopower(minimum_frequency=0.5, maximum_frequency=2.5,
+                                   samples_per_peak=8, fast=True)
+    P_rec = 1.0 / freqs[int(np.argmax(power))]
+
+    r = classify_recovery(P_rec, P_true, baseline=T)
+    assert r.recovered is True

--- a/ftperiodogram/tests/test_recovery.py
+++ b/ftperiodogram/tests/test_recovery.py
@@ -1,0 +1,145 @@
+"""Tests for the period-recovery metrics (ftperiodogram.recovery).
+
+Pure-function tests: boundary behaviour of the two recovery conventions, the
+configurable alias set, the exact-vs-harmonic split, and population aggregation.
+All instant and seed-free (the functions are deterministic).
+"""
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from ftperiodogram import recovery as rec
+
+
+# ----------------------------------------------------------------------
+# (a) hard fractional threshold
+# ----------------------------------------------------------------------
+def test_fractional_threshold_boundary():
+    P_true = 0.5
+    # rtol=0.01 -> half-width 0.005 in period
+    assert rec.recovered_fractional(0.5 + 0.0049, P_true) is True
+    assert rec.recovered_fractional(0.5 - 0.0049, P_true) is True
+    assert rec.recovered_fractional(0.5 + 0.0051, P_true) is False
+    # strictly-less-than: exactly on the boundary is NOT recovered
+    assert rec.recovered_fractional(P_true * 1.01, P_true) is False
+    # non-positive recovered period is never a match
+    assert rec.recovered_fractional(-0.5, P_true) is False
+    assert rec.recovered_fractional(0.0, P_true) is False
+
+
+def test_fractional_vectorized():
+    P_true = 0.5
+    out = rec.recovered_fractional(np.array([0.5, 0.55, 0.5004, -1.0]), P_true)
+    npt.assert_array_equal(out, [True, False, True, False])
+
+
+# ----------------------------------------------------------------------
+# (b) baseline-aware phase coherence
+# ----------------------------------------------------------------------
+def test_phase_coherence_boundary():
+    P_true, T, dphi = 0.5, 1000.0, 0.5
+    f_true = 1.0 / P_true                      # 2.0 cycles/day
+    df_thresh = dphi / T                        # 5e-4
+    # build P_rec with a chosen frequency error just inside / outside threshold
+    inside = 1.0 / (f_true + 0.8 * df_thresh)
+    outside = 1.0 / (f_true + 1.2 * df_thresh)
+    assert rec.recovered_phase_coherence(inside, P_true, T, dphi) is True
+    assert rec.recovered_phase_coherence(outside, P_true, T, dphi) is False
+
+
+def test_phase_coherence_is_stricter_than_fractional_for_long_baseline():
+    # a 1% period error passes the fractional test but, over a long baseline,
+    # accumulates ~20 cycles of drift -> fails phase coherence.
+    P_true, T = 0.5, 1000.0
+    P_rec = P_true * 1.005                       # 0.5% error, inside 1%
+    assert rec.recovered_fractional(P_rec, P_true) is True
+    assert rec.recovered_phase_coherence(P_rec, P_true, T, 0.5) is False
+
+
+def test_phase_coherence_requires_baseline():
+    with pytest.raises(ValueError):
+        rec.classify_recovery(0.5, 0.5, baseline=None,
+                              criterion='phase_coherence')
+
+
+# ----------------------------------------------------------------------
+# alias set
+# ----------------------------------------------------------------------
+def test_harmonic_alias_set_contents():
+    P_true = 0.5
+    aliases = rec.harmonic_alias_set(P_true)
+    by_name = {a.name: a for a in aliases}
+    # the four harmonic multiples, with correct alias periods
+    npt.assert_allclose(by_name['P/2'].P_alias, 0.25)
+    npt.assert_allclose(by_name['2P'].P_alias, 1.0)
+    npt.assert_allclose(by_name['P/3'].P_alias, 0.5 / 3.0)
+    npt.assert_allclose(by_name['3P'].P_alias, 1.5)
+    # 1-day beats: f_true = 2/day -> +1/day => P=1/3, -1/day => P=1
+    npt.assert_allclose(by_name['beat_+1/day'].P_alias, 1.0 / 3.0)
+    npt.assert_allclose(by_name['beat_-1/day'].P_alias, 1.0)
+    # -2/day drives f_true to exactly 0 -> dropped (non-positive frequency)
+    assert 'beat_-2/day' not in by_name
+    assert 'beat_+2/day' in by_name
+    # 1-year beat present and close to P_true (tiny frequency offset)
+    npt.assert_allclose(by_name['beat_+1/year'].P_alias,
+                        1.0 / (2.0 + 1.0 / 365.25), rtol=1e-9)
+
+
+# ----------------------------------------------------------------------
+# classify_recovery: exact vs exact-or-harmonic
+# ----------------------------------------------------------------------
+def test_classify_exact():
+    r = rec.classify_recovery(0.5004, 0.5)
+    assert r.exact and r.exact_or_harmonic and r.recovered
+    assert r.alias_name is None
+    assert r.criterion == 'fractional'
+
+
+def test_classify_harmonic_double_period():
+    r = rec.classify_recovery(1.0, 0.5)          # P_rec = 2 P_true
+    assert r.exact is False
+    assert r.exact_or_harmonic is True
+    assert r.alias_name == '2P'
+    assert r.recovered is True                   # count_harmonics default True
+    # turning harmonics off demotes it to a miss
+    r2 = rec.classify_recovery(1.0, 0.5, count_harmonics=False)
+    assert r2.recovered is False
+    assert r2.exact_or_harmonic is True          # still reported on the second curve
+
+
+def test_classify_miss():
+    r = rec.classify_recovery(0.37, 0.5)         # not exact, not a listed alias
+    assert not r.exact and not r.exact_or_harmonic and not r.recovered
+    assert r.alias_name is None
+
+
+def test_classify_phase_coherence_criterion():
+    r = rec.classify_recovery(0.5 * 1.005, 0.5, baseline=1000.0,
+                              criterion='phase_coherence', delta_phi_max=0.5)
+    assert r.criterion == 'phase_coherence'
+    assert r.exact is False                       # 0.5% error fails over T=1000
+
+
+# ----------------------------------------------------------------------
+# population aggregation
+# ----------------------------------------------------------------------
+def test_recovery_rate_aggregation():
+    results = [
+        rec.classify_recovery(0.5004, 0.5),   # exact
+        rec.classify_recovery(0.5002, 0.5),   # exact
+        rec.classify_recovery(1.0, 0.5),      # harmonic 2P
+        rec.classify_recovery(0.37, 0.5),     # miss
+    ]
+    summary = rec.recovery_rate(results)
+    assert summary['n'] == 4
+    npt.assert_allclose(summary['exact'], 0.5)
+    npt.assert_allclose(summary['exact_or_harmonic'], 0.75)
+    npt.assert_allclose(summary['recovered'], 0.75)
+    assert summary['alias_breakdown'] == {'2P': 1}
+
+
+def test_recovery_rate_empty():
+    summary = rec.recovery_rate([])
+    assert summary['n'] == 0
+    assert summary['recovered'] == 0.0
+    assert summary['alias_breakdown'] == {}

--- a/ftperiodogram/tests/test_simulate.py
+++ b/ftperiodogram/tests/test_simulate.py
@@ -1,0 +1,146 @@
+"""Tests for the light-curve simulator and cadence model (ftperiodogram.simulate).
+
+Bounded and seeded (RandomState) -- small epoch counts, no network.  The cadence
+tests assert the seasonal-gap / per-band-count structure; the simulator tests
+assert the single-band sorted-t contract, an exact noise-free round trip, and that
+shuffled multiband output is unsorted yet consumable by the multiband modeler.
+"""
+from collections import Counter
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from ftperiodogram.template import Template
+from ftperiodogram import simulate as sim
+from ftperiodogram import FastMultibandTemplatePeriodogram
+
+
+def _template():
+    return Template([1.0, 0.3], [0.0, 0.1])
+
+
+# ----------------------------------------------------------------------
+# error-vs-magnitude model
+# ----------------------------------------------------------------------
+def test_err_model_monotone_and_clipped():
+    f = sim.exp_mag_error()
+    assert float(f(21.0)) > float(f(15.0))         # fainter => larger sigma
+    assert float(f(0.0)) == pytest.approx(0.01)    # clipped to floor at bright end
+    assert float(f(100.0)) == pytest.approx(0.5)   # clipped to sigma_max at faint end
+
+
+# ----------------------------------------------------------------------
+# synthetic cadence
+# ----------------------------------------------------------------------
+def test_synthetic_cadence_seasonal_gaps_single_band():
+    cad = sim.SyntheticCadence(n_epochs=80, season_length_days=200.0,
+                               season_period_days=365.25,
+                               baseline_days=3 * 365.25, random_state=0)
+    s = cad.sample()
+    assert s.bands is None
+    assert s.t.size == 80
+    assert np.all(np.diff(s.t) >= 0)               # globally sorted
+    assert np.all(sim._in_season(s.t, 0.0, 200.0, 365.25))  # every epoch in-season
+    assert cad.baseline == pytest.approx(3 * 365.25)
+
+
+def test_synthetic_cadence_per_band_counts():
+    cad = sim.SyntheticCadence(n_epochs={'g': 40, 'r': 30}, bands=['g', 'r'],
+                               random_state=1)
+    s = cad.sample()
+    assert s.bands is not None
+    counts = Counter(s.bands.tolist())
+    assert counts == {'g': 40, 'r': 30}
+    assert np.all(np.diff(s.t) >= 0)               # globally sorted across bands
+
+
+def test_synthetic_cadence_is_deterministic():
+    cad = sim.SyntheticCadence(n_epochs=40, random_state=7)
+    npt.assert_array_equal(cad.sample().t, cad.sample().t)
+
+
+def test_synthetic_cadence_rejects_dict_without_bands():
+    with pytest.raises(ValueError):
+        sim.SyntheticCadence(n_epochs={'g': 10})
+
+
+def test_cadence_base_is_abstract():
+    with pytest.raises(NotImplementedError):
+        sim.Cadence().sample()
+
+
+# ----------------------------------------------------------------------
+# single-band simulator
+# ----------------------------------------------------------------------
+def test_simulate_lightcurve_sorted_and_noise_free_roundtrip():
+    tmpl = _template()
+    cad = sim.SyntheticCadence(n_epochs=50, random_state=2)
+    lc = sim.simulate_lightcurve(tmpl, period=0.6, cadence=cad, amplitude=0.4,
+                                 mean_mag=16.0, tau=0.2, random_state=3,
+                                 add_noise=False)
+    assert np.all(np.diff(lc.t) >= 0)              # single-band sorted-t contract
+    assert np.all(lc.dy > 0)
+    assert lc.period == 0.6
+    npt.assert_allclose(lc.frequency, 1.0 / 0.6)
+    expected = 16.0 + 0.4 * np.asarray(tmpl(lc.t / 0.6 - 0.2))
+    npt.assert_allclose(lc.y, expected)            # noise-free == the exact model
+
+
+def test_simulate_lightcurve_noise_scales_with_dy():
+    tmpl = _template()
+    cad = sim.SyntheticCadence(n_epochs=400, random_state=9)
+    clean = sim.simulate_lightcurve(tmpl, 0.6, cad, random_state=4, add_noise=False)
+    noisy = sim.simulate_lightcurve(tmpl, 0.6, cad, random_state=4, add_noise=True)
+    resid = (noisy.y - clean.y) / noisy.dy          # standardized residuals ~ N(0,1)
+    assert abs(np.std(resid) - 1.0) < 0.2
+
+
+def test_simulate_lightcurve_rejects_multiband_cadence():
+    cad = sim.SyntheticCadence(n_epochs=20, bands=['g', 'r'], random_state=0)
+    with pytest.raises(ValueError):
+        sim.simulate_lightcurve(_template(), 0.6, cad)
+
+
+# ----------------------------------------------------------------------
+# multiband simulator
+# ----------------------------------------------------------------------
+def test_simulate_multiband_floating_offsets_roundtrip():
+    tmpl = _template()
+    cad = sim.SyntheticCadence(n_epochs=30, bands=['g', 'r', 'i'], random_state=4)
+    boff = {'g': 0.0, 'r': -0.6, 'i': 0.4}
+    bamp = {'g': 1.0, 'r': 0.8, 'i': 0.6}
+    lc = sim.simulate_multiband_lightcurve(
+        tmpl, period=0.55, cadence=cad, amplitude=0.5, mean_mag=15.0, tau=0.1,
+        band_amplitudes=bamp, band_offsets=boff, random_state=5,
+        add_noise=False, shuffle=False)
+    for b in ('g', 'r', 'i'):
+        m = lc.bands == b
+        phase = lc.t[m] / 0.55 - 0.1
+        expected = 15.0 + boff[b] + 0.5 * bamp[b] * np.asarray(tmpl(phase))
+        npt.assert_allclose(lc.y[m], expected)
+
+
+def test_simulate_multiband_shuffle_unsorted_but_fits():
+    tmpl = _template()
+    cad = sim.SyntheticCadence(n_epochs=40, bands=['g', 'r'], random_state=6)
+    lc = sim.simulate_multiband_lightcurve(tmpl, 0.5, cad, amplitude=0.5,
+                                           random_state=8, shuffle=True)
+    assert not np.all(np.diff(lc.t) >= 0)          # global order is shuffled
+    model = FastMultibandTemplatePeriodogram([tmpl], mode='floating_offsets')
+    model.fit(lc.t, lc.y, lc.bands, lc.dy)
+    f, p = model.autopower(minimum_frequency=1.0, maximum_frequency=3.0)
+    assert np.all(np.isfinite(p))
+
+
+def test_simulate_multiband_missing_band_key_raises():
+    cad = sim.SyntheticCadence(n_epochs=10, bands=['g', 'r'], random_state=0)
+    with pytest.raises(ValueError):
+        sim.simulate_multiband_lightcurve(_template(), 0.6, cad,
+                                          band_offsets={'g': 0.0})  # missing 'r'
+
+
+def test_simulate_multiband_rejects_single_band_cadence():
+    cad = sim.SyntheticCadence(n_epochs=20, random_state=0)
+    with pytest.raises(ValueError):
+        sim.simulate_multiband_lightcurve(_template(), 0.6, cad)

--- a/ftperiodogram/tests/test_validation.py
+++ b/ftperiodogram/tests/test_validation.py
@@ -1,0 +1,136 @@
+"""Tests for the recovery scorer + K-sweep driver (ftperiodogram.validation).
+
+The driver bookkeeping (monotone assembly, the single-cosine baseline, masks,
+the explicit-grid guard, K validation) is tested with a fast content-blind fake
+scorer.  A separate bounded test exercises the *real* scorer + FTP on a tiny
+seeded synthetic population (no network), asserting it runs and is reproducible.
+"""
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from ftperiodogram.template import Template
+from ftperiodogram.simulate import SyntheticCadence
+from ftperiodogram import validation as val
+
+
+# ----------------------------------------------------------------------
+# tiny synthetic vocabulary (common H=4) so build_template_catalog runs
+# ----------------------------------------------------------------------
+_ARCH = [
+    (np.array([1.0, 0.5, 0.33, 0.25]), np.array([0.0, 0.10, 0.05, 0.02])),
+    (np.array([1.0, 0.05, 0.0, 0.0]), np.array([0.0, 0.0, 0.0, 0.0])),
+    (np.array([0.2, 1.0, 0.10, 0.05]), np.array([0.0, 0.0, 0.0, 0.0])),
+]
+
+
+def _population(seed=0, n_per=5):
+    rng = np.random.RandomState(seed)
+    out = []
+    for c, s in _ARCH:
+        for _ in range(n_per):
+            out.append(Template(c + 0.02 * rng.randn(4), s + 0.02 * rng.randn(4)))
+    return out
+
+
+class _FakeScorer:
+    """Content-blind deterministic scorer: a size-k set covers the first 3k
+    sources.  Records the template sets it is called with."""
+
+    def __init__(self, n_sources=12):
+        self.n_sources = n_sources
+        self.criterion = 'fractional'
+        self.freqs = np.linspace(1.0, 3.0, 64)
+        self.calls = []
+
+    def __call__(self, templates, *, return_mask=False):
+        templates = list(templates)
+        self.calls.append(templates)
+        k = len(templates)
+        mask = np.arange(self.n_sources) < min(self.n_sources, 3 * k)
+        rate = float(mask.mean())
+        return (rate, mask) if return_mask else rate
+
+
+# ----------------------------------------------------------------------
+# driver logic (fake scorer, instant)
+# ----------------------------------------------------------------------
+def test_k_sweep_monotone_and_above_baseline():
+    res = val.k_sweep_recovery(_population(seed=1), cadence=None,
+                               k_values=(1, 2, 3), scorer=_FakeScorer(12),
+                               random_state=0)
+    assert np.all(np.diff(res.recovery) >= 0)         # coverage rises with K
+    assert res.recovery[-1] >= res.baseline_recovery
+    assert res.n_sources == 12
+    npt.assert_array_equal(res.k_values, [1, 2, 3])
+
+
+def test_k_sweep_baseline_is_single_cosine():
+    scorer = _FakeScorer()
+    val.k_sweep_recovery(_population(seed=1), cadence=None, k_values=(2,),
+                         scorer=scorer, random_state=0)
+    first = scorer.calls[0]                            # baseline scored first
+    assert len(first) == 1
+    npt.assert_allclose(first[0].c_n, [1.0])           # H=1 single cosine == GLS
+    npt.assert_allclose(first[0].s_n, [0.0])
+
+
+def test_k_sweep_requires_explicit_grid():
+    with pytest.raises(ValueError):                    # no scorer and no grid
+        val.k_sweep_recovery(_population(seed=1), cadence=None, k_values=(1, 2))
+
+
+def test_k_sweep_return_masks_shapes():
+    res = val.k_sweep_recovery(_population(seed=1), cadence=None,
+                               k_values=(1, 2), scorer=_FakeScorer(10),
+                               return_masks=True, random_state=0)
+    assert len(res.recovery_by_k) == 2
+    assert all(m.shape == (10,) for m in res.recovery_by_k)
+    assert res.baseline_mask.shape == (10,)
+    npt.assert_allclose(res.recovery[0], res.recovery_by_k[0].mean())
+
+
+def test_k_sweep_rejects_bad_k():
+    scorer = _FakeScorer()
+    with pytest.raises(ValueError):
+        val.k_sweep_recovery(_population(seed=1), cadence=None, k_values=(0,),
+                             scorer=scorer)
+    with pytest.raises(ValueError):
+        val.k_sweep_recovery(_population(seed=1), cadence=None, k_values=(999,),
+                             scorer=scorer)
+
+
+# ----------------------------------------------------------------------
+# real scorer + FTP (bounded, seeded, no network)
+# ----------------------------------------------------------------------
+def test_recovery_scorer_deterministic_and_masked():
+    templates = _population(seed=1)
+    cad = SyntheticCadence(n_epochs={'g': 20, 'r': 20}, bands=['g', 'r'],
+                           baseline_days=365.25, random_state=2)
+    scorer = val.make_recovery_scorer(cad, templates,
+                                      freqs=val.frequency_grid(1.0, 3.0, 150),
+                                      n_sources=6, random_state=0)
+    rate1, mask1 = scorer(templates[:3], return_mask=True)
+    rate2, mask2 = scorer(templates[:3], return_mask=True)
+    npt.assert_array_equal(mask1, mask2)               # frozen population -> deterministic
+    assert rate1 == pytest.approx(mask1.mean())
+    assert 0.0 <= rate1 <= 1.0
+    masks = scorer.source_masks(templates[:4])
+    assert masks.shape == (4, 6)
+
+
+def test_k_sweep_real_scorer_runs_and_is_reproducible():
+    templates = _population(seed=1)
+    cad = SyntheticCadence(n_epochs={'g': 20, 'r': 20}, bands=['g', 'r'],
+                           baseline_days=365.25, random_state=2)
+    kw = dict(k_values=(1, 3), f_min=1.0, f_max=3.0, n_freq=150, n_sources=6,
+              random_state=0)
+    r1 = val.k_sweep_recovery(templates, cad, **kw)
+    r2 = val.k_sweep_recovery(templates, cad, **kw)
+    assert r1.recovery.shape == (2,)
+    assert np.all(np.isfinite(r1.recovery))
+    assert 0.0 <= r1.baseline_recovery <= 1.0
+    assert r1.freq_grid[2] == 150                       # n_freq
+    npt.assert_allclose(r1.freq_grid[:2], (1.0, 3.0), atol=0.02)  # NFFT-snapped band
+    assert r1.criterion == 'fractional'
+    npt.assert_array_equal(r1.recovery, r2.recovery)   # fully reproducible

--- a/ftperiodogram/tests/test_validation.py
+++ b/ftperiodogram/tests/test_validation.py
@@ -134,3 +134,14 @@ def test_k_sweep_real_scorer_runs_and_is_reproducible():
     npt.assert_allclose(r1.freq_grid[:2], (1.0, 3.0), atol=0.02)  # NFFT-snapped band
     assert r1.criterion == 'fractional'
     npt.assert_array_equal(r1.recovery, r2.recovery)   # fully reproducible
+
+
+def test_harness_public_api_exports():
+    import ftperiodogram as ftp
+    for name in ('Cadence', 'SyntheticCadence', 'exp_mag_error',
+                 'simulate_lightcurve', 'simulate_multiband_lightcurve',
+                 'recovered_fractional', 'recovered_phase_coherence',
+                 'harmonic_alias_set', 'classify_recovery', 'recovery_rate',
+                 'RecoveryScorer', 'make_recovery_scorer', 'k_sweep_recovery',
+                 'KSweepResult', 'frequency_grid'):
+        assert hasattr(ftp, name)

--- a/ftperiodogram/validation.py
+++ b/ftperiodogram/validation.py
@@ -1,0 +1,241 @@
+"""Recovery scorer + K-sweep driver (Phase 3.2 harness orchestration).
+
+This is the FTP-coupled layer that ties the simulator and the recovery metrics to
+the periodogram and the vocabulary builder:
+
+* :class:`RecoveryScorer` -- simulates a population of multiband light curves ONCE
+  (frozen, seeded), then scores any candidate template set by the fraction of
+  sources whose period it recovers.  Because the population is frozen, every
+  template set is scored against the *same* injected light curves, the per-source
+  recovered mask is aligned across calls, and the result is deterministic -- the
+  three properties the greedy selector (catalog_builder, ``method='greedy'``)
+  relies on.
+* :func:`k_sweep_recovery` -- the headline recovery-vs-K curve: for each K it builds
+  a size-K vocabulary with :func:`~ftperiodogram.catalog_builder.build_template_catalog`
+  and scores it, with FTP@H=1 (a single-cosine template) as the GLS-equivalent
+  lower-bound baseline, all on one explicit ``[f_min, f_max]`` grid.
+
+The recovery scorer is the seam the K-sweep and the greedy selector share.
+Search grids are explicit ``[f_min, f_max]`` -- never a Nyquist heuristic.
+"""
+from collections import namedtuple
+
+import numpy as np
+
+from .template import Template
+from .multiband import FastMultibandTemplatePeriodogram
+from .catalog_builder import build_template_catalog
+from . import simulate as _sim
+from . import recovery as _rec
+
+
+def frequency_grid(f_min, f_max, n_freq):
+    """Explicit uniform search grid over ``[f_min, f_max]`` with ``n_freq`` points.
+
+    Refuses the Nyquist heuristic (all three bounds are required).  The grid is
+    NFFT-aligned -- ``freqs[0]`` is an integer multiple of ``df`` -- which the fast
+    summations require; ``f_min`` is snapped to the nearest such multiple (a shift
+    of at most ``df/2``).
+    """
+    if f_min is None or f_max is None or n_freq is None:
+        raise ValueError("explicit f_min, f_max, n_freq are required "
+                         "(set the search band by [f_min, f_max], not nyquist_factor)")
+    f_min, f_max, n_freq = float(f_min), float(f_max), int(n_freq)
+    if not 0 < f_min < f_max:
+        raise ValueError("require 0 < f_min < f_max")
+    if n_freq < 2:
+        raise ValueError("n_freq must be >= 2")
+    df = (f_max - f_min) / (n_freq - 1)
+    nf0 = int(round(f_min / df))
+    return df * (nf0 + np.arange(n_freq))
+
+
+def _align_grid(freqs):
+    """Snap a uniform ascending grid so ``freqs[0]`` is an integer multiple of
+    ``df`` (the NFFT fast-summation requirement).  Idempotent on grids from
+    :func:`frequency_grid`."""
+    freqs = np.asarray(freqs, dtype=float)
+    if freqs.ndim != 1 or freqs.size < 2:
+        raise ValueError("freqs must be a 1-D grid with >= 2 points")
+    df = freqs[1] - freqs[0]
+    if df <= 0 or not np.allclose(np.diff(freqs), df, rtol=1e-6, atol=0):
+        raise ValueError("freqs must be a uniformly-spaced ascending grid")
+    nf0 = int(round(freqs[0] / df))
+    return df * (nf0 + np.arange(freqs.size))
+
+
+# ----------------------------------------------------------------------
+# Recovery scorer (frozen population)
+# ----------------------------------------------------------------------
+class RecoveryScorer(object):
+    """Score candidate template sets by simulated period recovery.
+
+    The population of ``n_sources`` multiband light curves is simulated once at
+    construction (truth shapes drawn from ``truth_templates``, injected periods
+    sampled in the grid band unless ``p_true`` is given) and frozen.  Calling the
+    scorer runs the FTP multiband periodogram (catalog mode) for the candidate set
+    over the explicit grid and returns the recovery rate -- the fraction of
+    sources whose recovered period passes :func:`ftperiodogram.recovery.classify_recovery`.
+    ``harmonic_aware`` selects exact (default) vs exact-or-harmonic recovery.
+    """
+
+    def __init__(self, cadence, truth_templates, *, freqs, n_sources=64,
+                 p_true=None, mode='floating_offsets', criterion='fractional',
+                 harmonic_aware=False, delta_phi_max=0.5, rtol=0.01,
+                 amplitude=0.5, mean_mag=15.0, band_amplitudes=None,
+                 band_offsets=None, random_state=0):
+        self.freqs = _align_grid(freqs)        # NFFT-aligned (snaps if needed)
+        self.n_sources = int(n_sources)
+        self.mode = mode
+        self.criterion = criterion
+        self.harmonic_aware = bool(harmonic_aware)
+        self.delta_phi_max = float(delta_phi_max)
+        self.rtol = float(rtol)
+
+        rng = _sim._as_rng(random_state)
+        truth_templates = list(truth_templates)
+        if not truth_templates:
+            raise ValueError("truth_templates is empty")
+
+        f_min, f_max = float(self.freqs.min()), float(self.freqs.max())
+        if p_true is None:
+            self.p_true = 1.0 / rng.uniform(f_min, f_max, size=self.n_sources)
+        else:
+            p = np.atleast_1d(np.asarray(p_true, dtype=float))
+            if p.size == 1:
+                self.p_true = np.full(self.n_sources, float(p[0]))
+            elif p.size == self.n_sources:
+                self.p_true = p
+            else:
+                raise ValueError("p_true must be a scalar or length n_sources")
+
+        # Freeze the population: each source = one simulated multiband light curve.
+        self._sources = []
+        for i in range(self.n_sources):
+            truth = truth_templates[rng.randint(len(truth_templates))]
+            lc = _sim.simulate_multiband_lightcurve(
+                truth, self.p_true[i], cadence, amplitude=amplitude,
+                mean_mag=mean_mag, tau=rng.rand(), band_amplitudes=band_amplitudes,
+                band_offsets=band_offsets, random_state=rng, add_noise=True,
+                shuffle=True)
+            baseline = float(lc.t.max() - lc.t.min())
+            self._sources.append((lc.t, lc.y, lc.bands, lc.dy, self.p_true[i],
+                                  baseline))
+
+    def _recovered_one(self, templates, source):
+        t, y, bands, dy, P_true, baseline = source
+        model = FastMultibandTemplatePeriodogram(list(templates), mode=self.mode)
+        model.fit(t, y, bands, dy)
+        powers = model.power(self.freqs, fast=True, save_best_model=False)
+        P_rec = 1.0 / self.freqs[int(np.argmax(powers))]
+        result = _rec.classify_recovery(
+            P_rec, P_true, baseline=baseline, criterion=self.criterion,
+            rtol=self.rtol, delta_phi_max=self.delta_phi_max,
+            count_harmonics=self.harmonic_aware)
+        return bool(result.recovered)
+
+    def __call__(self, templates, *, return_mask=False):
+        """Recovery rate of ``templates`` over the frozen population.
+
+        Returns ``rate`` (a float) or ``(rate, mask)`` with the per-source boolean
+        recovered mask when ``return_mask`` -- the mask is what the greedy selector
+        needs to target the not-yet-recovered subset.
+        """
+        mask = np.array([self._recovered_one(templates, s)
+                         for s in self._sources], dtype=bool)
+        rate = float(mask.mean()) if mask.size else 0.0
+        return (rate, mask) if return_mask else rate
+
+    def source_masks(self, templates):
+        """Per-template standalone recovered masks, shape ``(len(templates), n_sources)``.
+
+        Each row is the recovered mask of that single template alone; the greedy
+        selector unions these (catalog power is the per-frequency max over the set,
+        so a union of standalone masks exactly models the catalog's recovery)."""
+        if not list(templates):
+            return np.zeros((0, self.n_sources), dtype=bool)
+        return np.array([self.__call__([tmpl], return_mask=True)[1]
+                         for tmpl in templates], dtype=bool)
+
+
+def make_recovery_scorer(cadence, truth_templates, *, freqs, n_sources=64,
+                         p_true=None, mode='floating_offsets',
+                         criterion='fractional', harmonic_aware=False,
+                         delta_phi_max=0.5, rtol=0.01, amplitude=0.5,
+                         mean_mag=15.0, band_amplitudes=None, band_offsets=None,
+                         random_state=0):
+    """Build a :class:`RecoveryScorer` over a frozen simulated population."""
+    return RecoveryScorer(
+        cadence, truth_templates, freqs=freqs, n_sources=n_sources, p_true=p_true,
+        mode=mode, criterion=criterion, harmonic_aware=harmonic_aware,
+        delta_phi_max=delta_phi_max, rtol=rtol, amplitude=amplitude,
+        mean_mag=mean_mag, band_amplitudes=band_amplitudes,
+        band_offsets=band_offsets, random_state=random_state)
+
+
+# ----------------------------------------------------------------------
+# K-sweep driver
+# ----------------------------------------------------------------------
+KSweepResult = namedtuple(
+    'KSweepResult',
+    ['k_values', 'recovery', 'recovery_by_k', 'baseline_recovery',
+     'baseline_mask', 'n_sources', 'freq_grid', 'criterion', 'seed'])
+
+
+def k_sweep_recovery(templates, cadence, k_values=(1, 2, 4, 8), *, scorer=None,
+                     recovery_config=None, f_min=None, f_max=None, n_freq=None,
+                     n_sources=64, p_true=None, mode='floating_offsets',
+                     include_baseline=True, catalog_kwargs=None,
+                     return_masks=False, random_state=0):
+    """Recovery-vs-K curve for vocabularies built from ``templates``.
+
+    For each K in ``k_values`` a size-K vocabulary is built with
+    :func:`build_template_catalog` (``method='pam'``) and scored against the same
+    frozen simulated population; ``include_baseline`` adds the FTP@H=1
+    (single-cosine, GLS-equivalent) lower bound.  Either pass a prebuilt ``scorer``
+    or let one be built from the explicit grid (``f_min``/``f_max``/``n_freq``
+    required) and ``recovery_config``.  Returns a :class:`KSweepResult`.
+    """
+    templates = list(templates)
+    k_values = sorted({int(k) for k in k_values})
+    if not k_values:
+        raise ValueError("k_values is empty")
+    if k_values[0] < 1 or k_values[-1] > len(templates):
+        raise ValueError("each K must be in [1, len(templates)]; got %r for %d "
+                         "templates" % (k_values, len(templates)))
+
+    catalog_kwargs = dict(catalog_kwargs or {})
+    catalog_kwargs.setdefault('random_state', random_state)
+
+    if scorer is None:
+        freqs = frequency_grid(f_min, f_max, n_freq)
+        scorer = make_recovery_scorer(
+            cadence, templates, freqs=freqs, n_sources=n_sources, p_true=p_true,
+            mode=mode, random_state=random_state, **dict(recovery_config or {}))
+
+    baseline_recovery, baseline_mask = None, None
+    if include_baseline:
+        gls = [Template([1.0], [0.0])]                # H=1 single cosine == GLS
+        if return_masks:
+            baseline_recovery, baseline_mask = scorer(gls, return_mask=True)
+        else:
+            baseline_recovery = scorer(gls)
+
+    recovery = np.empty(len(k_values), dtype=float)
+    recovery_by_k = [] if return_masks else None
+    for i, K in enumerate(k_values):
+        vocab = build_template_catalog(templates, K, method='pam', **catalog_kwargs)
+        if return_masks:
+            rate, mask = scorer(vocab, return_mask=True)
+            recovery_by_k.append(mask)
+        else:
+            rate = scorer(vocab)
+        recovery[i] = rate
+
+    return KSweepResult(
+        k_values=np.asarray(k_values, dtype=int), recovery=recovery,
+        recovery_by_k=recovery_by_k, baseline_recovery=baseline_recovery,
+        baseline_mask=baseline_mask, n_sources=scorer.n_sources,
+        freq_grid=(float(scorer.freqs.min()), float(scorer.freqs.max()),
+                   int(scorer.freqs.size)),
+        criterion=scorer.criterion, seed=int(random_state))


### PR DESCRIPTION
Implements the synthetic-cadence core of the Phase-3.2 validation harness (design memo §2 + §A.1, PLAN §3.2) and wires the recovery-driven `method='greedy'` seam left open by PR #38. Branches off `dev`.

## What's added
- **`simulate.py`** — `Cadence` ABC + `SyntheticCadence` (random epochs · yearly seasonal gaps · per-band epoch counts · heteroscedastic error-vs-mag), and single/multiband light-curve simulators matching the modeler's `y = a·template(f·(t−τ)) + c`. A real ZTF DR22 cadence drops in later as a `Cadence` subclass with zero churn to the simulators or metrics.
- **`recovery.py`** — pure-numpy period-recovery metrics: hard 1% fractional (the headline), baseline-aware phase coherence `|Δf|·T < δφ_max` (default 0.5), a configurable harmonic/window-beat alias set (P/2, 2P, P/3, 3P + 1-day/1-year beats), and `classify_recovery` (exact vs exact-or-harmonic, names the matching alias).
- **`validation.py`** — `RecoveryScorer` (population simulated once, frozen + seeded → deterministic per-source recovered masks + `source_masks`), `make_recovery_scorer`, `k_sweep_recovery` (recovery-vs-K via `build_template_catalog` + multiband catalog-mode FTP, with **FTP@H=1 `Template([1,0])` as the GLS-equivalent lower bound**), and `frequency_grid` (explicit `[f_min,f_max]`, NFFT-aligned).
- **`catalog_builder.py`** — `method='greedy'` wired: `_greedy_select` is set-cover on the not-yet-recovered subset using `source_masks`, padded to K by orbit-diversity when recovery saturates; returns the same `(medoid_idx, labels, cost)` triple as PAM. New params `scorer=`, `candidate_pool=`.
- Public exports + an API-export test.

## Locked design decisions (from session Q&A)
- Headline criterion = **hard 1% fractional**; phase coherence computed/reported as the strict secondary.
- **δφ_max = 0.5** (half-cycle / Rayleigh main-lobe half-width), tunable.
- Greedy objective uses **exact** recovery; exact-or-harmonic always also available.

## Correctness note
Catalog-mode power is the per-frequency **max** over templates, so adding a template can move the global peak and *break* a recovery — it is **not** a monotone union. Greedy therefore uses the standalone-mask union only as the selection *signal*, while the reported `cost = 1 − scorer(vocab)` is the **actual** catalog recovery (honest where the union over-counts).

## Honoring project rules
Explicit `[f_min,f_max]` grids (never `nyquist_factor`); stdlib + numpy only (no new deps); bounded, seeded, fast tests under `tests/`.

## Tests
**66 new tests, all green.** Full suite: 195 passed, 1 skipped (Sesar network fetch).

> Note: `test_slow_template_modeler.py::test_zero_noise[None-2/3]` fail on `dev` too — a **pre-existing unseeded-flaky** reference-modeler test, unrelated to this PR.

## Deferred (next sessions)
Real ZTF/Chen-2020/Gaia cadence; contaminant + variable-type confusion matrix; classification feature bank (§3.3); joint/EM optimizer (§3.4); Full greedy (`candidate_pool='pam:M'`, strong-singleton, backward-elim); Sesar-oracle cost-vs-accuracy panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)